### PR TITLE
Add support for ACL secret_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In order to run the full suite of Acceptance tests:
 
 1. setup test environment
   ```sh
-  nomad agent -dev
+  nomad agent -dev -acl-enabled
   ```
 
 2. set nomad agent address (if differs from `http://localhost:4646`) and run tests

--- a/README.md
+++ b/README.md
@@ -54,10 +54,18 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-In order to run the full suite of Acceptance tests, run `make testacc`.
+In order to run the full suite of Acceptance tests:
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+1. setup test environment
+  ```sh
+  nomad agent -dev
+  ```
 
-```sh
-$ make testacc
-```
+2. set nomad agent address (if differs from `http://localhost:4646`) and run tests
+  ```sh
+  NOMAD_ADDR=http://<host>:<port> make testacc
+  ```
+
+Acceptance tests expect fresh instance of nomad agent, so all steps must be performed every time tests are executed. 
+
+*Note:* Acceptance tests create real resources, and may cost money to run.

--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -42,6 +42,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NOMAD_CLIENT_KEY", ""),
 				Description: "A path to a PEM-encoded private key, required if cert_file is specified.",
 			},
+			"secret_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NOMAD_TOKEN", ""),
+				Description: "ACL token secret for API requests.",
+			},
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -59,6 +65,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config.TLSConfig.CACert = d.Get("ca_file").(string)
 	config.TLSConfig.ClientCert = d.Get("cert_file").(string)
 	config.TLSConfig.ClientKey = d.Get("key_file").(string)
+	config.SecretID = d.Get("secret_id").(string)
 
 	client, err := api.NewClient(config)
 	if err != nil {

--- a/nomad/provider_test.go
+++ b/nomad/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -14,7 +16,7 @@ import (
 //   and extract the "nomad" binary
 //
 // - Run the following to start the Nomad agent in development mode:
-//       nomad agent -dev
+//       nomad agent -dev -acl-enabled
 //
 // - Run the Terraform acceptance tests as usual:
 //       make testacc TEST=./builtin/providers/nomad
@@ -29,11 +31,16 @@ func TestProvider(t *testing.T) {
 
 var testProvider *schema.Provider
 var testProviders map[string]terraform.ResourceProvider
+var managementToken string
 
 func init() {
 	testProvider = Provider().(*schema.Provider)
 	testProviders = map[string]terraform.ResourceProvider{
 		"nomad": testProvider,
+	}
+
+	if v := os.Getenv(resource.TestEnvVar); v == "1" {
+		setupAcl()
 	}
 }
 
@@ -41,4 +48,26 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("NOMAD_ADDR"); v == "" {
 		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
 	}
+	os.Setenv("NOMAD_TOKEN", managementToken)
+}
+
+func testAccPreCheckAnonymous(t *testing.T) {
+	if v := os.Getenv("NOMAD_ADDR"); v == "" {
+		os.Setenv("NOMAD_ADDR", "http://127.0.0.1:4646")
+	}
+	os.Unsetenv("NOMAD_TOKEN")
+}
+
+func setupAcl() {
+	client, err := api.NewClient(&api.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	acl, _, err := client.ACLTokens().Bootstrap(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	managementToken = acl.SecretID
 }

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -243,8 +243,7 @@ job "bar" {
         task "foo" {
             driver = "raw_exec"
             config {
-                command = "/bin/sleep"
-                args = ["1"]
+                command = "/bin/true"
             }
 
             resources {
@@ -308,7 +307,7 @@ func testResourceJob_updateCheck(s *terraform.State) error {
 var testResourceJob_parameterizedJob = `
 resource "nomad_job" "test" {
     jobspec = <<EOT
-job "bar" {
+job "parameterized" {
     datacenters = ["dc1"]
     type = "batch"
     parameterized {

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -10,7 +10,21 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 
 	"github.com/hashicorp/nomad/api"
+	"regexp"
 )
+
+func TestResourceJob_basic_anonymous(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheckAnonymous(t) },
+		Steps: []r.TestStep{
+			{
+				Config:      testResourceJob_initialConfig,
+				ExpectError: regexp.MustCompile(".* 403 .*"),
+			},
+		},
+	})
+}
 
 func TestResourceJob_basic(t *testing.T) {
 	r.Test(t, r.TestCase{

--- a/vendor/github.com/hashicorp/nomad/api/acl.go
+++ b/vendor/github.com/hashicorp/nomad/api/acl.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"fmt"
+	"time"
+)
+
+// ACLPolicies is used to query the ACL Policy endpoints.
+type ACLPolicies struct {
+	client *Client
+}
+
+// ACLPolicies returns a new handle on the ACL policies.
+func (c *Client) ACLPolicies() *ACLPolicies {
+	return &ACLPolicies{client: c}
+}
+
+// List is used to dump all of the policies.
+func (a *ACLPolicies) List(q *QueryOptions) ([]*ACLPolicyListStub, *QueryMeta, error) {
+	var resp []*ACLPolicyListStub
+	qm, err := a.client.query("/v1/acl/policies", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
+}
+
+// Upsert is used to create or update a policy
+func (a *ACLPolicies) Upsert(policy *ACLPolicy, q *WriteOptions) (*WriteMeta, error) {
+	if policy == nil || policy.Name == "" {
+		return nil, fmt.Errorf("missing policy name")
+	}
+	wm, err := a.client.write("/v1/acl/policy/"+policy.Name, policy, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Delete is used to delete a policy
+func (a *ACLPolicies) Delete(policyName string, q *WriteOptions) (*WriteMeta, error) {
+	if policyName == "" {
+		return nil, fmt.Errorf("missing policy name")
+	}
+	wm, err := a.client.delete("/v1/acl/policy/"+policyName, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Info is used to query a specific policy
+func (a *ACLPolicies) Info(policyName string, q *QueryOptions) (*ACLPolicy, *QueryMeta, error) {
+	if policyName == "" {
+		return nil, nil, fmt.Errorf("missing policy name")
+	}
+	var resp ACLPolicy
+	wm, err := a.client.query("/v1/acl/policy/"+policyName, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// ACLTokens is used to query the ACL token endpoints.
+type ACLTokens struct {
+	client *Client
+}
+
+// ACLTokens returns a new handle on the ACL tokens.
+func (c *Client) ACLTokens() *ACLTokens {
+	return &ACLTokens{client: c}
+}
+
+// Bootstrap is used to get the initial bootstrap token
+func (a *ACLTokens) Bootstrap(q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	var resp ACLToken
+	wm, err := a.client.write("/v1/acl/bootstrap", nil, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// List is used to dump all of the tokens.
+func (a *ACLTokens) List(q *QueryOptions) ([]*ACLTokenListStub, *QueryMeta, error) {
+	var resp []*ACLTokenListStub
+	qm, err := a.client.query("/v1/acl/tokens", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
+}
+
+// Create is used to create a token
+func (a *ACLTokens) Create(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	if token.AccessorID != "" {
+		return nil, nil, fmt.Errorf("cannot specify Accessor ID")
+	}
+	var resp ACLToken
+	wm, err := a.client.write("/v1/acl/token", token, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// Update is used to update an existing token
+func (a *ACLTokens) Update(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
+	if token.AccessorID == "" {
+		return nil, nil, fmt.Errorf("missing accessor ID")
+	}
+	var resp ACLToken
+	wm, err := a.client.write("/v1/acl/token/"+token.AccessorID,
+		token, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// Delete is used to delete a token
+func (a *ACLTokens) Delete(accessorID string, q *WriteOptions) (*WriteMeta, error) {
+	if accessorID == "" {
+		return nil, fmt.Errorf("missing accessor ID")
+	}
+	wm, err := a.client.delete("/v1/acl/token/"+accessorID, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Info is used to query a token
+func (a *ACLTokens) Info(accessorID string, q *QueryOptions) (*ACLToken, *QueryMeta, error) {
+	if accessorID == "" {
+		return nil, nil, fmt.Errorf("missing accessor ID")
+	}
+	var resp ACLToken
+	wm, err := a.client.query("/v1/acl/token/"+accessorID, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// Self is used to query our own token
+func (a *ACLTokens) Self(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
+	var resp ACLToken
+	wm, err := a.client.query("/v1/acl/token/self", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+// ACLPolicyListStub is used to for listing ACL policies
+type ACLPolicyListStub struct {
+	Name        string
+	Description string
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// ACLPolicy is used to represent an ACL policy
+type ACLPolicy struct {
+	Name        string
+	Description string
+	Rules       string
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// ACLToken represents a client token which is used to Authenticate
+type ACLToken struct {
+	AccessorID  string
+	SecretID    string
+	Name        string
+	Type        string
+	Policies    []string
+	Global      bool
+	CreateTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+type ACLTokenListStub struct {
+	AccessorID  string
+	Name        string
+	Type        string
+	Policies    []string
+	Global      bool
+	CreateTime  time.Time
+	CreateIndex uint64
+	ModifyIndex uint64
+}

--- a/vendor/github.com/hashicorp/nomad/api/allocations.go
+++ b/vendor/github.com/hashicorp/nomad/api/allocations.go
@@ -48,49 +48,31 @@ func (a *Allocations) Info(allocID string, q *QueryOptions) (*Allocation, *Query
 }
 
 func (a *Allocations) Stats(alloc *Allocation, q *QueryOptions) (*AllocResourceUsage, error) {
-	node, _, err := a.client.Nodes().Info(alloc.NodeID, q)
+	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
 	if err != nil {
 		return nil, err
 	}
-	if node.Status == "down" {
-		return nil, NodeDownErr
-	}
-	if node.HTTPAddr == "" {
-		return nil, fmt.Errorf("http addr of the node where alloc %q is running is not advertised", alloc.ID)
-	}
-	client, err := NewClient(a.client.config.CopyConfig(node.HTTPAddr, node.TLSEnabled))
-	if err != nil {
-		return nil, err
-	}
+
 	var resp AllocResourceUsage
-	_, err = client.query("/v1/client/allocation/"+alloc.ID+"/stats", &resp, nil)
+	_, err = nodeClient.query("/v1/client/allocation/"+alloc.ID+"/stats", &resp, nil)
 	return &resp, err
 }
 
 func (a *Allocations) GC(alloc *Allocation, q *QueryOptions) error {
-	node, _, err := a.client.Nodes().Info(alloc.NodeID, q)
-	if err != nil {
-		return err
-	}
-	if node.Status == "down" {
-		return NodeDownErr
-	}
-	if node.HTTPAddr == "" {
-		return fmt.Errorf("http addr of the node where alloc %q is running is not advertised", alloc.ID)
-	}
-	client, err := NewClient(a.client.config.CopyConfig(node.HTTPAddr, node.TLSEnabled))
+	nodeClient, err := a.client.GetNodeClient(alloc.NodeID, q)
 	if err != nil {
 		return err
 	}
 
 	var resp struct{}
-	_, err = client.query("/v1/client/allocation"+alloc.ID+"/gc", &resp, nil)
+	_, err = nodeClient.query("/v1/client/allocation/"+alloc.ID+"/gc", &resp, nil)
 	return err
 }
 
 // Allocation is used for serialization of allocations.
 type Allocation struct {
 	ID                 string
+	Namespace          string
 	EvalID             string
 	Name               string
 	NodeID             string
@@ -125,6 +107,7 @@ type AllocationMetric struct {
 	NodesExhausted     int
 	ClassExhausted     map[string]int
 	DimensionExhausted map[string]int
+	QuotaExhausted     []string
 	Scores             map[string]float64
 	AllocationTime     time.Duration
 	CoalescedFailures  int

--- a/vendor/github.com/hashicorp/nomad/api/api.go
+++ b/vendor/github.com/hashicorp/nomad/api/api.go
@@ -24,6 +24,9 @@ type QueryOptions struct {
 	// by the Config
 	Region string
 
+	// Namespace is the target namespace for the query.
+	Namespace string
+
 	// AllowStale allows any Nomad server (non-leader) to service
 	// a read. This allows for lower latency and higher throughput
 	AllowStale bool
@@ -41,6 +44,9 @@ type QueryOptions struct {
 
 	// Set HTTP parameters on the query.
 	Params map[string]string
+
+	// AuthToken is the secret ID of an ACL token
+	AuthToken string
 }
 
 // WriteOptions are used to parameterize a write
@@ -48,6 +54,12 @@ type WriteOptions struct {
 	// Providing a datacenter overwrites the region provided
 	// by the Config
 	Region string
+
+	// Namespace is the target namespace for the write.
+	Namespace string
+
+	// AuthToken is the secret ID of an ACL token
+	AuthToken string
 }
 
 // QueryMeta is used to return meta data about a query
@@ -94,9 +106,14 @@ type Config struct {
 	// Region to use. If not provided, the default agent region is used.
 	Region string
 
-	// HttpClient is the client to use. Default will be
-	// used if not provided.
-	HttpClient *http.Client
+	// SecretID to use. This can be overwritten per request.
+	SecretID string
+
+	// Namespace to use. If not provided the default namespace is used.
+	Namespace string
+
+	// httpClient is the client to use. Default will be used if not provided.
+	httpClient *http.Client
 
 	// HttpAuth is the auth info to use for http access.
 	HttpAuth *HttpBasicAuth
@@ -110,19 +127,26 @@ type Config struct {
 	TLSConfig *TLSConfig
 }
 
-// CopyConfig copies the configuration with a new address
-func (c *Config) CopyConfig(address string, tlsEnabled bool) *Config {
+// ClientConfig copies the configuration with a new client address, region, and
+// whether the client has TLS enabled.
+func (c *Config) ClientConfig(region, address string, tlsEnabled bool) *Config {
 	scheme := "http"
 	if tlsEnabled {
 		scheme = "https"
 	}
+	defaultConfig := DefaultConfig()
 	config := &Config{
 		Address:    fmt.Sprintf("%s://%s", scheme, address),
-		Region:     c.Region,
-		HttpClient: c.HttpClient,
+		Region:     region,
+		Namespace:  c.Namespace,
+		httpClient: defaultConfig.httpClient,
+		SecretID:   c.SecretID,
 		HttpAuth:   c.HttpAuth,
 		WaitTime:   c.WaitTime,
-		TLSConfig:  c.TLSConfig,
+		TLSConfig:  c.TLSConfig.Copy(),
+	}
+	if tlsEnabled && config.TLSConfig != nil {
+		config.TLSConfig.TLSServerName = fmt.Sprintf("client.%s.nomad", region)
 	}
 
 	return config
@@ -153,14 +177,24 @@ type TLSConfig struct {
 	Insecure bool
 }
 
+func (t *TLSConfig) Copy() *TLSConfig {
+	if t == nil {
+		return nil
+	}
+
+	nt := new(TLSConfig)
+	*nt = *t
+	return nt
+}
+
 // DefaultConfig returns a default configuration for the client
 func DefaultConfig() *Config {
 	config := &Config{
 		Address:    "http://127.0.0.1:4646",
-		HttpClient: cleanhttp.DefaultClient(),
+		httpClient: cleanhttp.DefaultClient(),
 		TLSConfig:  &TLSConfig{},
 	}
-	transport := config.HttpClient.Transport.(*http.Transport)
+	transport := config.httpClient.Transport.(*http.Transport)
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -168,6 +202,12 @@ func DefaultConfig() *Config {
 
 	if addr := os.Getenv("NOMAD_ADDR"); addr != "" {
 		config.Address = addr
+	}
+	if v := os.Getenv("NOMAD_REGION"); v != "" {
+		config.Region = v
+	}
+	if v := os.Getenv("NOMAD_NAMESPACE"); v != "" {
+		config.Namespace = v
 	}
 	if auth := os.Getenv("NOMAD_HTTP_AUTH"); auth != "" {
 		var username, password string
@@ -203,13 +243,18 @@ func DefaultConfig() *Config {
 			config.TLSConfig.Insecure = insecure
 		}
 	}
-
+	if v := os.Getenv("NOMAD_TOKEN"); v != "" {
+		config.SecretID = v
+	}
 	return config
 }
 
 // ConfigureTLS applies a set of TLS configurations to the the HTTP client.
 func (c *Config) ConfigureTLS() error {
-	if c.HttpClient == nil {
+	if c.TLSConfig == nil {
+		return nil
+	}
+	if c.httpClient == nil {
 		return fmt.Errorf("config HTTP Client must be set")
 	}
 
@@ -228,7 +273,7 @@ func (c *Config) ConfigureTLS() error {
 		}
 	}
 
-	clientTLSConfig := c.HttpClient.Transport.(*http.Transport).TLSClientConfig
+	clientTLSConfig := c.httpClient.Transport.(*http.Transport).TLSClientConfig
 	rootConfig := &rootcerts.Config{
 		CAFile: c.TLSConfig.CACert,
 		CAPath: c.TLSConfig.CAPath,
@@ -265,8 +310,8 @@ func NewClient(config *Config) (*Client, error) {
 		return nil, fmt.Errorf("invalid address '%s': %v", config.Address, err)
 	}
 
-	if config.HttpClient == nil {
-		config.HttpClient = defConfig.HttpClient
+	if config.httpClient == nil {
+		config.httpClient = defConfig.httpClient
 	}
 
 	// Configure the TLS cofigurations
@@ -280,9 +325,67 @@ func NewClient(config *Config) (*Client, error) {
 	return client, nil
 }
 
+// Address return the address of the Nomad agent
+func (c *Client) Address() string {
+	return c.config.Address
+}
+
 // SetRegion sets the region to forward API requests to.
 func (c *Client) SetRegion(region string) {
 	c.config.Region = region
+}
+
+// SetNamespace sets the namespace to forward API requests to.
+func (c *Client) SetNamespace(namespace string) {
+	c.config.Namespace = namespace
+}
+
+// GetNodeClient returns a new Client that will dial the specified node. If the
+// QueryOptions is set, its region will be used.
+func (c *Client) GetNodeClient(nodeID string, q *QueryOptions) (*Client, error) {
+	return c.getNodeClientImpl(nodeID, q, c.Nodes().Info)
+}
+
+// nodeLookup is the definition of a function used to lookup a node. This is
+// largely used to mock the lookup in tests.
+type nodeLookup func(nodeID string, q *QueryOptions) (*Node, *QueryMeta, error)
+
+// getNodeClientImpl is the implementation of creating a API client for
+// contacting a node. It takes a function to lookup the node such that it can be
+// mocked during tests.
+func (c *Client) getNodeClientImpl(nodeID string, q *QueryOptions, lookup nodeLookup) (*Client, error) {
+	node, _, err := lookup(nodeID, q)
+	if err != nil {
+		return nil, err
+	}
+	if node.Status == "down" {
+		return nil, NodeDownErr
+	}
+	if node.HTTPAddr == "" {
+		return nil, fmt.Errorf("http addr of node %q (%s) is not advertised", node.Name, nodeID)
+	}
+
+	var region string
+	switch {
+	case q != nil && q.Region != "":
+		// Prefer the region set in the query parameter
+		region = q.Region
+	case c.config.Region != "":
+		// If the client is configured for a particular region use that
+		region = c.config.Region
+	default:
+		// No region information is given so use the default.
+		region = "global"
+	}
+
+	// Get an API client for the node
+	conf := c.config.ClientConfig(region, node.HTTPAddr, node.TLSEnabled)
+	return NewClient(conf)
+}
+
+// SetSecretID sets the ACL token secret for API requests.
+func (c *Client) SetSecretID(secretID string) {
+	c.config.SecretID = secretID
 }
 
 // request is used to help build up a request
@@ -291,6 +394,7 @@ type request struct {
 	method string
 	url    *url.URL
 	params url.Values
+	token  string
 	body   io.Reader
 	obj    interface{}
 }
@@ -303,6 +407,12 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Region != "" {
 		r.params.Set("region", q.Region)
+	}
+	if q.Namespace != "" {
+		r.params.Set("namespace", q.Namespace)
+	}
+	if q.AuthToken != "" {
+		r.token = q.AuthToken
 	}
 	if q.AllowStale {
 		r.params.Set("stale", "")
@@ -334,6 +444,12 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 	}
 	if q.Region != "" {
 		r.params.Set("region", q.Region)
+	}
+	if q.Namespace != "" {
+		r.params.Set("namespace", q.Namespace)
+	}
+	if q.AuthToken != "" {
+		r.token = q.AuthToken
 	}
 }
 
@@ -367,6 +483,10 @@ func (r *request) toHTTP() (*http.Request, error) {
 	}
 
 	req.Header.Add("Accept-Encoding", "gzip")
+	if r.token != "" {
+		req.Header.Set("X-Nomad-Token", r.token)
+	}
+
 	req.URL.Host = r.url.Host
 	req.URL.Scheme = r.url.Scheme
 	req.Host = r.url.Host
@@ -394,8 +514,14 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 	if c.config.Region != "" {
 		r.params.Set("region", c.config.Region)
 	}
+	if c.config.Namespace != "" {
+		r.params.Set("namespace", c.config.Namespace)
+	}
 	if c.config.WaitTime != 0 {
 		r.params.Set("wait", durToMsec(r.config.WaitTime))
+	}
+	if c.config.SecretID != "" {
+		r.token = r.config.SecretID
 	}
 
 	// Add in the query parameters, if any
@@ -435,7 +561,7 @@ func (c *Client) doRequest(r *request) (time.Duration, *http.Response, error) {
 		return 0, nil, err
 	}
 	start := time.Now()
-	resp, err := c.config.HttpClient.Do(req)
+	resp, err := c.config.httpClient.Do(req)
 	diff := time.Now().Sub(start)
 
 	// If the response is compressed, we swap the body's reader.
@@ -479,7 +605,7 @@ func (c *Client) rawQuery(endpoint string, q *QueryOptions) (io.ReadCloser, erro
 	return resp.Body, nil
 }
 
-// Query is used to do a GET request against an endpoint
+// query is used to do a GET request against an endpoint
 // and deserialize the response into an interface using
 // standard Nomad conventions.
 func (c *Client) query(endpoint string, out interface{}, q *QueryOptions) (*QueryMeta, error) {
@@ -488,6 +614,32 @@ func (c *Client) query(endpoint string, out interface{}, q *QueryOptions) (*Quer
 		return nil, err
 	}
 	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	if err := decodeBody(resp, out); err != nil {
+		return nil, err
+	}
+	return qm, nil
+}
+
+// putQuery is used to do a PUT request when doing a read against an endpoint
+// and deserialize the response into an interface using standard Nomad
+// conventions.
+func (c *Client) putQuery(endpoint string, in, out interface{}, q *QueryOptions) (*QueryMeta, error) {
+	r, err := c.newRequest("PUT", endpoint)
+	if err != nil {
+		return nil, err
+	}
+	r.setQueryOptions(q)
+	r.obj = in
 	rtt, resp, err := requireOK(c.doRequest(r))
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
+++ b/vendor/github.com/hashicorp/nomad/api/contexts/contexts.go
@@ -1,0 +1,15 @@
+package contexts
+
+// Context defines the scope in which a search for Nomad object operates
+type Context string
+
+const (
+	Allocs      Context = "allocs"
+	Deployments Context = "deployment"
+	Evals       Context = "evals"
+	Jobs        Context = "jobs"
+	Nodes       Context = "nodes"
+	Namespaces  Context = "namespaces"
+	Quotas      Context = "quotas"
+	All         Context = "all"
+)

--- a/vendor/github.com/hashicorp/nomad/api/deployments.go
+++ b/vendor/github.com/hashicorp/nomad/api/deployments.go
@@ -14,7 +14,7 @@ func (c *Client) Deployments() *Deployments {
 	return &Deployments{client: c}
 }
 
-// List is used to dump all of the evaluations.
+// List is used to dump all of the deployments.
 func (d *Deployments) List(q *QueryOptions) ([]*Deployment, *QueryMeta, error) {
 	var resp []*Deployment
 	qm, err := d.client.query("/v1/deployments", &resp, q)
@@ -29,7 +29,7 @@ func (d *Deployments) PrefixList(prefix string) ([]*Deployment, *QueryMeta, erro
 	return d.List(&QueryOptions{Prefix: prefix})
 }
 
-// Info is used to query a single evaluation by its ID.
+// Info is used to query a single deployment by its ID.
 func (d *Deployments) Info(deploymentID string, q *QueryOptions) (*Deployment, *QueryMeta, error) {
 	var resp Deployment
 	qm, err := d.client.query("/v1/deployment/"+deploymentID, &resp, q)
@@ -125,6 +125,7 @@ func (d *Deployments) SetAllocHealth(deploymentID string, healthy, unhealthy []s
 // Deployment is used to serialize an deployment.
 type Deployment struct {
 	ID                string
+	Namespace         string
 	JobID             string
 	JobVersion        uint64
 	JobModifyIndex    uint64

--- a/vendor/github.com/hashicorp/nomad/api/evaluations.go
+++ b/vendor/github.com/hashicorp/nomad/api/evaluations.go
@@ -58,6 +58,7 @@ type Evaluation struct {
 	Priority             int
 	Type                 string
 	TriggeredBy          string
+	Namespace            string
 	JobID                string
 	JobModifyIndex       uint64
 	NodeID               string
@@ -72,6 +73,7 @@ type Evaluation struct {
 	FailedTGAllocs       map[string]*AllocationMetric
 	ClassEligibility     map[string]bool
 	EscapedComputedClass bool
+	QuotaLimitReached    string
 	AnnotatePlan         bool
 	QueuedAllocations    map[string]int
 	SnapshotIndex        uint64

--- a/vendor/github.com/hashicorp/nomad/api/jobs.go
+++ b/vendor/github.com/hashicorp/nomad/api/jobs.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorhill/cronexpr"
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 const (
@@ -21,6 +20,9 @@ const (
 
 	// PeriodicSpecCron is used for a cron spec.
 	PeriodicSpecCron = "cron"
+
+	// DefaultNamespace is the default namespace.
+	DefaultNamespace = "default"
 )
 
 const (
@@ -49,30 +51,43 @@ func (j *Jobs) Validate(job *Job, q *WriteOptions) (*JobValidateResponse, *Write
 	return &resp, wm, err
 }
 
+// RegisterOptions is used to pass through job registration parameters
+type RegisterOptions struct {
+	EnforceIndex   bool
+	ModifyIndex    uint64
+	PolicyOverride bool
+}
+
 // Register is used to register a new job. It returns the ID
 // of the evaluation, along with any errors encountered.
 func (j *Jobs) Register(job *Job, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
-
-	var resp JobRegisterResponse
-
-	req := &RegisterJobRequest{Job: job}
-	wm, err := j.client.write("/v1/jobs", req, &resp, q)
-	if err != nil {
-		return nil, nil, err
-	}
-	return &resp, wm, nil
+	return j.RegisterOpts(job, nil, q)
 }
 
 // EnforceRegister is used to register a job enforcing its job modify index.
 func (j *Jobs) EnforceRegister(job *Job, modifyIndex uint64, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
+	opts := RegisterOptions{EnforceIndex: true, ModifyIndex: modifyIndex}
+	return j.RegisterOpts(job, &opts, q)
+}
+
+// Register is used to register a new job. It returns the ID
+// of the evaluation, along with any errors encountered.
+func (j *Jobs) RegisterOpts(job *Job, opts *RegisterOptions, q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
+	// Format the request
+	req := &RegisterJobRequest{
+		Job: job,
+	}
+	if opts != nil {
+		if opts.EnforceIndex {
+			req.EnforceIndex = true
+			req.JobModifyIndex = opts.ModifyIndex
+		}
+		if opts.PolicyOverride {
+			req.PolicyOverride = true
+		}
+	}
 
 	var resp JobRegisterResponse
-
-	req := &RegisterJobRequest{
-		Job:            job,
-		EnforceIndex:   true,
-		JobModifyIndex: modifyIndex,
-	}
 	wm, err := j.client.write("/v1/jobs", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
@@ -205,21 +220,36 @@ func (j *Jobs) PeriodicForce(jobID string, q *WriteOptions) (string, *WriteMeta,
 	return resp.EvalID, wm, nil
 }
 
+// PlanOptions is used to pass through job planning parameters
+type PlanOptions struct {
+	Diff           bool
+	PolicyOverride bool
+}
+
 func (j *Jobs) Plan(job *Job, diff bool, q *WriteOptions) (*JobPlanResponse, *WriteMeta, error) {
+	opts := PlanOptions{Diff: diff}
+	return j.PlanOpts(job, &opts, q)
+}
+
+func (j *Jobs) PlanOpts(job *Job, opts *PlanOptions, q *WriteOptions) (*JobPlanResponse, *WriteMeta, error) {
 	if job == nil {
 		return nil, nil, fmt.Errorf("must pass non-nil job")
 	}
 
-	var resp JobPlanResponse
+	// Setup the request
 	req := &JobPlanRequest{
-		Job:  job,
-		Diff: diff,
+		Job: job,
 	}
+	if opts != nil {
+		req.Diff = opts.Diff
+		req.PolicyOverride = opts.PolicyOverride
+	}
+
+	var resp JobPlanResponse
 	wm, err := j.client.write("/v1/job/"+*job.ID+"/plan", req, &resp, q)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return &resp, wm, nil
 }
 
@@ -299,6 +329,20 @@ type UpdateStrategy struct {
 	Canary          *int           `mapstructure:"canary"`
 }
 
+// DefaultUpdateStrategy provides a baseline that can be used to upgrade
+// jobs with the old policy or for populating field defaults.
+func DefaultUpdateStrategy() *UpdateStrategy {
+	return &UpdateStrategy{
+		Stagger:         helper.TimeToPtr(30 * time.Second),
+		MaxParallel:     helper.IntToPtr(1),
+		HealthCheck:     helper.StringToPtr("checks"),
+		MinHealthyTime:  helper.TimeToPtr(10 * time.Second),
+		HealthyDeadline: helper.TimeToPtr(5 * time.Minute),
+		AutoRevert:      helper.BoolToPtr(false),
+		Canary:          helper.IntToPtr(0),
+	}
+}
+
 func (u *UpdateStrategy) Copy() *UpdateStrategy {
 	if u == nil {
 		return nil
@@ -372,35 +416,72 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 }
 
 func (u *UpdateStrategy) Canonicalize() {
+	d := DefaultUpdateStrategy()
+
 	if u.MaxParallel == nil {
-		u.MaxParallel = helper.IntToPtr(0)
+		u.MaxParallel = d.MaxParallel
 	}
 
-	d := structs.DefaultUpdateStrategy
-
 	if u.Stagger == nil {
-		u.Stagger = helper.TimeToPtr(d.Stagger)
+		u.Stagger = d.Stagger
 	}
 
 	if u.HealthCheck == nil {
-		u.HealthCheck = helper.StringToPtr(d.HealthCheck)
+		u.HealthCheck = d.HealthCheck
 	}
 
 	if u.HealthyDeadline == nil {
-		u.HealthyDeadline = helper.TimeToPtr(d.HealthyDeadline)
+		u.HealthyDeadline = d.HealthyDeadline
 	}
 
 	if u.MinHealthyTime == nil {
-		u.MinHealthyTime = helper.TimeToPtr(d.MinHealthyTime)
+		u.MinHealthyTime = d.MinHealthyTime
 	}
 
 	if u.AutoRevert == nil {
-		u.AutoRevert = helper.BoolToPtr(d.AutoRevert)
+		u.AutoRevert = d.AutoRevert
 	}
 
 	if u.Canary == nil {
-		u.Canary = helper.IntToPtr(d.Canary)
+		u.Canary = d.Canary
 	}
+}
+
+// Empty returns whether the UpdateStrategy is empty or has user defined values.
+func (u *UpdateStrategy) Empty() bool {
+	if u == nil {
+		return true
+	}
+
+	if u.Stagger != nil && *u.Stagger != 0 {
+		return false
+	}
+
+	if u.MaxParallel != nil && *u.MaxParallel != 0 {
+		return false
+	}
+
+	if u.HealthCheck != nil && *u.HealthCheck != "" {
+		return false
+	}
+
+	if u.MinHealthyTime != nil && *u.MinHealthyTime != 0 {
+		return false
+	}
+
+	if u.HealthyDeadline != nil && *u.HealthyDeadline != 0 {
+		return false
+	}
+
+	if u.AutoRevert != nil && *u.AutoRevert {
+		return false
+	}
+
+	if u.Canary != nil && *u.Canary != 0 {
+		return false
+	}
+
+	return true
 }
 
 // PeriodicConfig is for serializing periodic config for a job.
@@ -463,6 +544,7 @@ type ParameterizedJobConfig struct {
 type Job struct {
 	Stop              *bool
 	Region            *string
+	Namespace         *string
 	ID                *string
 	ParentID          *string
 	Name              *string
@@ -508,6 +590,9 @@ func (j *Job) Canonicalize() {
 	if j.ParentID == nil {
 		j.ParentID = helper.StringToPtr("")
 	}
+	if j.Namespace == nil {
+		j.Namespace = helper.StringToPtr(DefaultNamespace)
+	}
 	if j.Priority == nil {
 		j.Priority = helper.IntToPtr(50)
 	}
@@ -516,6 +601,9 @@ func (j *Job) Canonicalize() {
 	}
 	if j.Region == nil {
 		j.Region = helper.StringToPtr("global")
+	}
+	if j.Namespace == nil {
+		j.Namespace = helper.StringToPtr("default")
 	}
 	if j.Type == nil {
 		j.Type = helper.StringToPtr("service")
@@ -561,9 +649,10 @@ func (j *Job) Canonicalize() {
 
 // JobSummary summarizes the state of the allocations of a job
 type JobSummary struct {
-	JobID    string
-	Summary  map[string]TaskGroupSummary
-	Children *JobChildrenSummary
+	JobID     string
+	Namespace string
+	Summary   map[string]TaskGroupSummary
+	Children  *JobChildrenSummary
 
 	// Raft Indexes
 	CreateIndex uint64
@@ -692,6 +781,12 @@ func (j *Job) AddPeriodicConfig(cfg *PeriodicConfig) *Job {
 type WriteRequest struct {
 	// The target region for this write
 	Region string
+
+	// Namespace is the target namespace for this write
+	Namespace string
+
+	// SecretID is the secret ID of an ACL token
+	SecretID string
 }
 
 // JobValidateRequest is used to validate a job
@@ -709,7 +804,7 @@ type JobValidateResponse struct {
 	// ValidationErrors is a list of validation errors
 	ValidationErrors []string
 
-	// Error is a string version of any error that may have occured
+	// Error is a string version of any error that may have occurred
 	Error string
 
 	// Warnings contains any warnings about the given job. These may include
@@ -740,6 +835,7 @@ type JobRegisterRequest struct {
 	// register only occurs if the job is new.
 	EnforceIndex   bool
 	JobModifyIndex uint64
+	PolicyOverride bool
 
 	WriteRequest
 }
@@ -749,6 +845,7 @@ type RegisterJobRequest struct {
 	Job            *Job
 	EnforceIndex   bool   `json:",omitempty"`
 	JobModifyIndex uint64 `json:",omitempty"`
+	PolicyOverride bool   `json:",omitempty"`
 }
 
 // JobRegisterResponse is used to respond to a job registration
@@ -773,8 +870,9 @@ type JobDeregisterResponse struct {
 }
 
 type JobPlanRequest struct {
-	Job  *Job
-	Diff bool
+	Job            *Job
+	Diff           bool
+	PolicyOverride bool
 	WriteRequest
 }
 

--- a/vendor/github.com/hashicorp/nomad/api/jobs_testing.go
+++ b/vendor/github.com/hashicorp/nomad/api/jobs_testing.go
@@ -4,27 +4,27 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/helper"
-	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
 )
 
 func MockJob() *Job {
 	job := &Job{
 		Region:      helper.StringToPtr("global"),
-		ID:          helper.StringToPtr(structs.GenerateUUID()),
+		ID:          helper.StringToPtr(uuid.Generate()),
 		Name:        helper.StringToPtr("my-job"),
 		Type:        helper.StringToPtr("service"),
 		Priority:    helper.IntToPtr(50),
 		AllAtOnce:   helper.BoolToPtr(false),
 		Datacenters: []string{"dc1"},
 		Constraints: []*Constraint{
-			&Constraint{
+			{
 				LTarget: "${attr.kernel.name}",
 				RTarget: "linux",
 				Operand: "=",
 			},
 		},
 		TaskGroups: []*TaskGroup{
-			&TaskGroup{
+			{
 				Name:  helper.StringToPtr("web"),
 				Count: helper.IntToPtr(10),
 				EphemeralDisk: &EphemeralDisk{
@@ -37,7 +37,7 @@ func MockJob() *Job {
 					Mode:     helper.StringToPtr("delay"),
 				},
 				Tasks: []*Task{
-					&Task{
+					{
 						Name:   "web",
 						Driver: "exec",
 						Config: map[string]interface{}{
@@ -72,7 +72,7 @@ func MockJob() *Job {
 							CPU:      helper.IntToPtr(500),
 							MemoryMB: helper.IntToPtr(256),
 							Networks: []*NetworkResource{
-								&NetworkResource{
+								{
 									MBits:        helper.IntToPtr(50),
 									DynamicPorts: []Port{{Label: "http"}, {Label: "admin"}},
 								},

--- a/vendor/github.com/hashicorp/nomad/api/namespace.go
+++ b/vendor/github.com/hashicorp/nomad/api/namespace.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Namespaces is used to query the namespace endpoints.
+type Namespaces struct {
+	client *Client
+}
+
+// Namespaces returns a new handle on the namespaces.
+func (c *Client) Namespaces() *Namespaces {
+	return &Namespaces{client: c}
+}
+
+// List is used to dump all of the namespaces.
+func (n *Namespaces) List(q *QueryOptions) ([]*Namespace, *QueryMeta, error) {
+	var resp []*Namespace
+	qm, err := n.client.query("/v1/namespaces", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Sort(NamespaceIndexSort(resp))
+	return resp, qm, nil
+}
+
+// PrefixList is used to do a PrefixList search over namespaces
+func (n *Namespaces) PrefixList(prefix string, q *QueryOptions) ([]*Namespace, *QueryMeta, error) {
+	if q == nil {
+		q = &QueryOptions{Prefix: prefix}
+	} else {
+		q.Prefix = prefix
+	}
+
+	return n.List(q)
+}
+
+// Info is used to query a single namespace by its name.
+func (n *Namespaces) Info(name string, q *QueryOptions) (*Namespace, *QueryMeta, error) {
+	var resp Namespace
+	qm, err := n.client.query("/v1/namespace/"+name, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, qm, nil
+}
+
+// Register is used to register a namespace.
+func (n *Namespaces) Register(namespace *Namespace, q *WriteOptions) (*WriteMeta, error) {
+	wm, err := n.client.write("/v1/namespace", namespace, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Delete is used to delete a namespace
+func (n *Namespaces) Delete(namespace string, q *WriteOptions) (*WriteMeta, error) {
+	wm, err := n.client.delete(fmt.Sprintf("/v1/namespace/%s", namespace), nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Namespace is used to serialize a namespace.
+type Namespace struct {
+	Name        string
+	Description string
+	Quota       string
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// NamespaceIndexSort is a wrapper to sort Namespaces by CreateIndex. We
+// reverse the test so that we get the highest index first.
+type NamespaceIndexSort []*Namespace
+
+func (n NamespaceIndexSort) Len() int {
+	return len(n)
+}
+
+func (n NamespaceIndexSort) Less(i, j int) bool {
+	return n[i].CreateIndex > n[j].CreateIndex
+}
+
+func (n NamespaceIndexSort) Swap(i, j int) {
+	n[i], n[j] = n[j], n[i]
+}

--- a/vendor/github.com/hashicorp/nomad/api/nodes.go
+++ b/vendor/github.com/hashicorp/nomad/api/nodes.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 )
@@ -23,7 +22,7 @@ func (n *Nodes) List(q *QueryOptions) ([]*NodeListStub, *QueryMeta, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	sort.Sort(NodeIndexSort(resp))
+	sort.Sort(resp)
 	return resp, qm, nil
 }
 
@@ -73,38 +72,25 @@ func (n *Nodes) ForceEvaluate(nodeID string, q *WriteOptions) (string, *WriteMet
 }
 
 func (n *Nodes) Stats(nodeID string, q *QueryOptions) (*HostStats, error) {
-	node, _, err := n.client.Nodes().Info(nodeID, q)
-	if err != nil {
-		return nil, err
-	}
-	if node.HTTPAddr == "" {
-		return nil, fmt.Errorf("http addr of the node %q is running is not advertised", nodeID)
-	}
-	client, err := NewClient(n.client.config.CopyConfig(node.HTTPAddr, node.TLSEnabled))
+	nodeClient, err := n.client.GetNodeClient(nodeID, q)
 	if err != nil {
 		return nil, err
 	}
 	var resp HostStats
-	if _, err := client.query("/v1/client/stats", &resp, nil); err != nil {
+	if _, err := nodeClient.query("/v1/client/stats", &resp, nil); err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
 func (n *Nodes) GC(nodeID string, q *QueryOptions) error {
-	node, _, err := n.client.Nodes().Info(nodeID, q)
+	nodeClient, err := n.client.GetNodeClient(nodeID, q)
 	if err != nil {
 		return err
 	}
-	if node.HTTPAddr == "" {
-		return fmt.Errorf("http addr of the node %q is running is not advertised", nodeID)
-	}
-	client, err := NewClient(n.client.config.CopyConfig(node.HTTPAddr, node.TLSEnabled))
-	if err != nil {
-		return err
-	}
+
 	var resp struct{}
-	_, err = client.query("/v1/client/gc", &resp, nil)
+	_, err = nodeClient.query("/v1/client/gc", &resp, nil)
 	return err
 }
 
@@ -169,6 +155,7 @@ type NodeListStub struct {
 	Datacenter        string
 	Name              string
 	NodeClass         string
+	Version           string
 	Drain             bool
 	Status            string
 	StatusDescription string

--- a/vendor/github.com/hashicorp/nomad/api/operator.go
+++ b/vendor/github.com/hashicorp/nomad/api/operator.go
@@ -75,7 +75,7 @@ func (op *Operator) RaftRemovePeerByAddress(address string, q *WriteOptions) err
 
 	// TODO (alexdadgar) Currently we made address a query parameter. Once
 	// IDs are in place this will be DELETE /v1/operator/raft/peer/<id>.
-	r.params.Set("address", string(address))
+	r.params.Set("address", address)
 
 	_, resp, err := requireOK(op.c.doRequest(r))
 	if err != nil {

--- a/vendor/github.com/hashicorp/nomad/api/quota.go
+++ b/vendor/github.com/hashicorp/nomad/api/quota.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Quotas is used to query the quotas endpoints.
+type Quotas struct {
+	client *Client
+}
+
+// Quotas returns a new handle on the quotas.
+func (c *Client) Quotas() *Quotas {
+	return &Quotas{client: c}
+}
+
+// List is used to dump all of the quota specs
+func (q *Quotas) List(qo *QueryOptions) ([]*QuotaSpec, *QueryMeta, error) {
+	var resp []*QuotaSpec
+	qm, err := q.client.query("/v1/quotas", &resp, qo)
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Sort(QuotaSpecIndexSort(resp))
+	return resp, qm, nil
+}
+
+// PrefixList is used to do a PrefixList search over quota specs
+func (q *Quotas) PrefixList(prefix string, qo *QueryOptions) ([]*QuotaSpec, *QueryMeta, error) {
+	if qo == nil {
+		qo = &QueryOptions{Prefix: prefix}
+	} else {
+		qo.Prefix = prefix
+	}
+
+	return q.List(qo)
+}
+
+// ListUsage is used to dump all of the quota usages
+func (q *Quotas) ListUsage(qo *QueryOptions) ([]*QuotaUsage, *QueryMeta, error) {
+	var resp []*QuotaUsage
+	qm, err := q.client.query("/v1/quota-usages", &resp, qo)
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Sort(QuotaUsageIndexSort(resp))
+	return resp, qm, nil
+}
+
+// PrefixList is used to do a PrefixList search over quota usages
+func (q *Quotas) PrefixListUsage(prefix string, qo *QueryOptions) ([]*QuotaUsage, *QueryMeta, error) {
+	if qo == nil {
+		qo = &QueryOptions{Prefix: prefix}
+	} else {
+		qo.Prefix = prefix
+	}
+
+	return q.ListUsage(qo)
+}
+
+// Info is used to query a single quota spec by its name.
+func (q *Quotas) Info(name string, qo *QueryOptions) (*QuotaSpec, *QueryMeta, error) {
+	var resp QuotaSpec
+	qm, err := q.client.query("/v1/quota/"+name, &resp, qo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, qm, nil
+}
+
+// Usage is used to query a single quota usage by its name.
+func (q *Quotas) Usage(name string, qo *QueryOptions) (*QuotaUsage, *QueryMeta, error) {
+	var resp QuotaUsage
+	qm, err := q.client.query("/v1/quota/usage/"+name, &resp, qo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, qm, nil
+}
+
+// Register is used to register a quota spec.
+func (q *Quotas) Register(spec *QuotaSpec, qo *WriteOptions) (*WriteMeta, error) {
+	wm, err := q.client.write("/v1/quota", spec, nil, qo)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Delete is used to delete a quota spec
+func (q *Quotas) Delete(quota string, qo *WriteOptions) (*WriteMeta, error) {
+	wm, err := q.client.delete(fmt.Sprintf("/v1/quota/%s", quota), nil, qo)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// QuotaSpec specifies the allowed resource usage across regions.
+type QuotaSpec struct {
+	// Name is the name for the quota object
+	Name string
+
+	// Description is an optional description for the quota object
+	Description string
+
+	// Limits is the set of quota limits encapsulated by this quota object. Each
+	// limit applies quota in a particular region and in the future over a
+	// particular priority range and datacenter set.
+	Limits []*QuotaLimit
+
+	// Raft indexes to track creation and modification
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// QuotaLimit describes the resource limit in a particular region.
+type QuotaLimit struct {
+	// Region is the region in which this limit has affect
+	Region string
+
+	// RegionLimit is the quota limit that applies to any allocation within a
+	// referencing namespace in the region. A value of zero is treated as
+	// unlimited and a negative value is treated as fully disallowed. This is
+	// useful for once we support GPUs
+	RegionLimit *Resources
+
+	// Hash is the hash of the object and is used to make replication efficient.
+	Hash []byte
+}
+
+// QuotaUsage is the resource usage of a Quota
+type QuotaUsage struct {
+	Name        string
+	Used        map[string]*QuotaLimit
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+// QuotaSpecIndexSort is a wrapper to sort QuotaSpecs by CreateIndex. We
+// reverse the test so that we get the highest index first.
+type QuotaSpecIndexSort []*QuotaSpec
+
+func (q QuotaSpecIndexSort) Len() int {
+	return len(q)
+}
+
+func (q QuotaSpecIndexSort) Less(i, j int) bool {
+	return q[i].CreateIndex > q[j].CreateIndex
+}
+
+func (q QuotaSpecIndexSort) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}
+
+// QuotaUsageIndexSort is a wrapper to sort QuotaUsages by CreateIndex. We
+// reverse the test so that we get the highest index first.
+type QuotaUsageIndexSort []*QuotaUsage
+
+func (q QuotaUsageIndexSort) Len() int {
+	return len(q)
+}
+
+func (q QuotaUsageIndexSort) Less(i, j int) bool {
+	return q[i].CreateIndex > q[j].CreateIndex
+}
+
+func (q QuotaUsageIndexSort) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}
+
+// QuotaLimitSort is a wrapper to sort QuotaLimits
+type QuotaLimitSort []*QuotaLimit
+
+func (q QuotaLimitSort) Len() int {
+	return len(q)
+}
+
+func (q QuotaLimitSort) Less(i, j int) bool {
+	return q[i].Region < q[j].Region
+}
+
+func (q QuotaLimitSort) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}

--- a/vendor/github.com/hashicorp/nomad/api/search.go
+++ b/vendor/github.com/hashicorp/nomad/api/search.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"github.com/hashicorp/nomad/api/contexts"
+)
+
+type Search struct {
+	client *Client
+}
+
+// Search returns a handle on the Search endpoints
+func (c *Client) Search() *Search {
+	return &Search{client: c}
+}
+
+// PrefixSearch returns a list of matches for a particular context and prefix.
+func (s *Search) PrefixSearch(prefix string, context contexts.Context, q *QueryOptions) (*SearchResponse, *QueryMeta, error) {
+	var resp SearchResponse
+	req := &SearchRequest{Prefix: prefix, Context: context}
+
+	qm, err := s.client.putQuery("/v1/search", req, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &resp, qm, nil
+}
+
+type SearchRequest struct {
+	Prefix  string
+	Context contexts.Context
+	QueryOptions
+}
+
+type SearchResponse struct {
+	Matches     map[contexts.Context][]string
+	Truncations map[contexts.Context]bool
+	QueryMeta
+}

--- a/vendor/github.com/hashicorp/nomad/api/sentinel.go
+++ b/vendor/github.com/hashicorp/nomad/api/sentinel.go
@@ -1,0 +1,79 @@
+package api
+
+import "fmt"
+
+// SentinelPolicies is used to query the Sentinel Policy endpoints.
+type SentinelPolicies struct {
+	client *Client
+}
+
+// SentinelPolicies returns a new handle on the Sentinel policies.
+func (c *Client) SentinelPolicies() *SentinelPolicies {
+	return &SentinelPolicies{client: c}
+}
+
+// List is used to dump all of the policies.
+func (a *SentinelPolicies) List(q *QueryOptions) ([]*SentinelPolicyListStub, *QueryMeta, error) {
+	var resp []*SentinelPolicyListStub
+	qm, err := a.client.query("/v1/sentinel/policies", &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, qm, nil
+}
+
+// Upsert is used to create or update a policy
+func (a *SentinelPolicies) Upsert(policy *SentinelPolicy, q *WriteOptions) (*WriteMeta, error) {
+	if policy == nil || policy.Name == "" {
+		return nil, fmt.Errorf("missing policy name")
+	}
+	wm, err := a.client.write("/v1/sentinel/policy/"+policy.Name, policy, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Delete is used to delete a policy
+func (a *SentinelPolicies) Delete(policyName string, q *WriteOptions) (*WriteMeta, error) {
+	if policyName == "" {
+		return nil, fmt.Errorf("missing policy name")
+	}
+	wm, err := a.client.delete("/v1/sentinel/policy/"+policyName, nil, q)
+	if err != nil {
+		return nil, err
+	}
+	return wm, nil
+}
+
+// Info is used to query a specific policy
+func (a *SentinelPolicies) Info(policyName string, q *QueryOptions) (*SentinelPolicy, *QueryMeta, error) {
+	if policyName == "" {
+		return nil, nil, fmt.Errorf("missing policy name")
+	}
+	var resp SentinelPolicy
+	wm, err := a.client.query("/v1/sentinel/policy/"+policyName, &resp, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &resp, wm, nil
+}
+
+type SentinelPolicy struct {
+	Name             string
+	Description      string
+	Scope            string
+	EnforcementLevel string
+	Policy           string
+	CreateIndex      uint64
+	ModifyIndex      uint64
+}
+
+type SentinelPolicyListStub struct {
+	Name             string
+	Description      string
+	Scope            string
+	EnforcementLevel string
+	CreateIndex      uint64
+	ModifyIndex      uint64
+}

--- a/vendor/github.com/hashicorp/nomad/api/system.go
+++ b/vendor/github.com/hashicorp/nomad/api/system.go
@@ -15,3 +15,9 @@ func (s *System) GarbageCollect() error {
 	_, err := s.client.write("/v1/system/gc", &req, nil, nil)
 	return err
 }
+
+func (s *System) ReconcileSummaries() error {
+	var req struct{}
+	_, err := s.client.write("/v1/system/reconcile/summaries", &req, nil, nil)
+	return err
+}

--- a/vendor/github.com/hashicorp/nomad/helper/uuid/uuid.go
+++ b/vendor/github.com/hashicorp/nomad/helper/uuid/uuid.go
@@ -1,0 +1,21 @@
+package uuid
+
+import (
+	crand "crypto/rand"
+	"fmt"
+)
+
+// Generate is used to generate a random UUID
+func Generate() string {
+	buf := make([]byte, 16)
+	if _, err := crand.Read(buf); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
+	}
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
+}

--- a/vendor/github.com/hashicorp/nomad/helper/uuid/uuid_test.go
+++ b/vendor/github.com/hashicorp/nomad/helper/uuid/uuid_test.go
@@ -1,0 +1,22 @@
+package uuid
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	prev := Generate()
+	for i := 0; i < 100; i++ {
+		id := Generate()
+		if prev == id {
+			t.Fatalf("Should get a new ID!")
+		}
+
+		matched, err := regexp.MatchString(
+			"[\\da-f]{8}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{4}-[\\da-f]{12}", id)
+		if !matched || err != nil {
+			t.Fatalf("expected match %s %v %s", id, matched, err)
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -418,18 +418,33 @@
 			"revisionTime": "2015-06-09T07:04:31Z"
 		},
 		{
-			"checksumSHA1": "MayUXobY5OPh1zx4Dpi7m8x2Fig=",
+			"checksumSHA1": "VQKxpGw3rsGOqWTedM/4YVds8PE=",
 			"path": "github.com/hashicorp/nomad/api",
-			"revision": "902d759a2ab961c75f784cb34e88416f06a98b59",
-			"revisionTime": "2017-07-26T22:16:21Z",
-			"version": "=v0.6.0",
-			"versionExact": "v0.6.0"
+			"revision": "1292569ac11aacfe8555a6bd94c0faedae2138e7",
+			"revisionTime": "2017-11-01T17:00:21Z",
+			"version": "=v0.7.0",
+			"versionExact": "v0.7.0"
+		},
+		{
+			"checksumSHA1": "fqswK1Rf5F7cRNG+UHgY/gQFC78=",
+			"path": "github.com/hashicorp/nomad/api/contexts",
+			"revision": "1292569ac11aacfe8555a6bd94c0faedae2138e7",
+			"revisionTime": "2017-11-01T17:00:21Z",
+			"version": "=v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "PJhcrcP+0rcr5z7KX73Pb+16ydI=",
 			"path": "github.com/hashicorp/nomad/helper",
 			"revision": "902d759a2ab961c75f784cb34e88416f06a98b59",
 			"revisionTime": "2017-07-26T22:16:21Z",
+			"version": "=v0.6.0",
+			"versionExact": "v0.6.0"
+		},
+		{
+			"checksumSHA1": "QVyYB9f4qD1UMzdsee2leWCZhXg=",
+			"path": "github.com/hashicorp/nomad/helper/uuid",
+			"revision": "902d759a2ab961c75f784cb34e88416f06a98b59",
 			"version": "=v0.6.0",
 			"versionExact": "v0.6.0"
 		},


### PR DESCRIPTION
acctest was failing even before the changes, first commit fixes that (in the easiest way I could figure out)

nomad api had to updated to 0.7.0 for this.
It's basically `govendor fetch ...@=v0.7.0`