### PR TITLE
Implement an acl_token resource.

### DIFF
--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -53,7 +53,8 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 
 		ResourcesMap: map[string]*schema.Resource{
-			"nomad_job": resourceJob(),
+			"nomad_acl_token": resourceACLToken(),
+			"nomad_job":       resourceJob(),
 		},
 	}
 }

--- a/nomad/resource_acl_token.go
+++ b/nomad/resource_acl_token.go
@@ -1,0 +1,183 @@
+package nomad
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceACLToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceACLTokenCreate,
+		Update: resourceACLTokenUpdate,
+		Delete: resourceACLTokenDelete,
+		Read:   resourceACLTokenRead,
+		Exists: resourceACLTokenExists,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"accessor_id": {
+				Description: "Nomad-generated ID for this token.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+
+			"secret_id": {
+				Description: "The value that grants access to Nomad.",
+				Computed:    true,
+				Sensitive:   true,
+				Type:        schema.TypeString,
+			},
+
+			"name": {
+				Description: "Human-readable name for this token.",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+
+			"type": {
+				Description: "The type of token to create, 'client' or 'management'.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+
+			"policies": {
+				Description: "The ACL policies to associate with the token, if it's a 'client' type.",
+				Optional:    true,
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"global": {
+				Description: "Whether the token should be replicated to all regions or not.",
+				Optional:    true,
+				Type:        schema.TypeBool,
+				ForceNew:    true,
+				Default:     false,
+			},
+		},
+	}
+}
+
+func resourceACLTokenCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	policies := make([]string, 0, len(d.Get("policies").(*schema.Set).List()))
+	for _, pol := range d.Get("policies").(*schema.Set).List() {
+		policies = append(policies, pol.(string))
+	}
+
+	token := api.ACLToken{
+		Name:     d.Get("name").(string),
+		Type:     d.Get("type").(string),
+		Policies: policies,
+		Global:   d.Get("global").(bool),
+	}
+
+	// create our token
+	log.Println("[DEBUG] Creating ACL token")
+	resp, _, err := client.ACLTokens().Create(&token, nil)
+	if err != nil {
+		return fmt.Errorf("error creating ACL token: %s", err.Error())
+	}
+	log.Printf("[DEBUG] Created ACL token %q", resp.AccessorID)
+	d.SetId(resp.AccessorID)
+
+	d.Set("accessor_id", resp.AccessorID)
+	d.Set("secret_id", resp.SecretID)
+	d.Set("name", resp.Name)
+	d.Set("type", resp.Type)
+	d.Set("policies", resp.Policies)
+	d.Set("global", resp.Global)
+
+	return resourceACLTokenRead(d, meta)
+}
+
+func resourceACLTokenUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	policies := make([]string, 0, len(d.Get("policies").(*schema.Set).List()))
+	for _, pol := range d.Get("policies").(*schema.Set).List() {
+		policies = append(policies, pol.(string))
+	}
+
+	token := api.ACLToken{
+		AccessorID: d.Id(),
+		Name:       d.Get("name").(string),
+		Type:       d.Get("type").(string),
+		Policies:   policies,
+	}
+
+	// update the token
+	log.Printf("[DEBUG] Updating ACL token %q", d.Id())
+	_, _, err := client.ACLTokens().Update(&token, nil)
+	if err != nil {
+		return fmt.Errorf("error updating ACL token %q: %s", d.Id(), err.Error())
+	}
+	log.Printf("[DEBUG] Updated ACL token %q", d.Id())
+
+	return resourceACLTokenRead(d, meta)
+}
+
+func resourceACLTokenDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	accessor := d.Id()
+
+	// delete the token
+	log.Printf("[DEBUG] Deleting ACL token %q", accessor)
+	_, err := client.ACLTokens().Delete(accessor, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting ACL token %q: %s", accessor, err.Error())
+	}
+	log.Printf("[DEBUG] Deleted ACL token %q", accessor)
+
+	return nil
+}
+
+func resourceACLTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	accessor := d.Id()
+
+	// retrieve the token
+	log.Printf("[DEBUG] Reading ACL token %q", accessor)
+	token, _, err := client.ACLTokens().Info(accessor, nil)
+	if err != nil {
+		// we have Exists, so no need to handle 404
+		return fmt.Errorf("error reading ACL token %q: %s", accessor, err.Error())
+	}
+	log.Printf("[DEBUG] Read ACL token %q", accessor)
+
+	d.Set("name", token.Name)
+	d.Set("type", token.Type)
+	d.Set("policies", token.Policies)
+	d.Set("accessor_id", token.AccessorID)
+	d.Set("secret_id", token.SecretID)
+	d.Set("global", token.Global)
+
+	return nil
+}
+
+func resourceACLTokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	accessor := d.Id()
+	log.Printf("[DEBUG] Checking if ACL token %q exists", accessor)
+	_, _, err := client.ACLTokens().Info(accessor, nil)
+	if err != nil {
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+
+		return true, fmt.Errorf("error checking for ACL token %q: %#v", accessor, err)
+	}
+
+	return true, nil
+}

--- a/nomad/resource_acl_token_test.go
+++ b/nomad/resource_acl_token_test.go
@@ -1,0 +1,238 @@
+package nomad
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func TestResourceACLToken_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLToken_initialConfig(),
+				Check:  testResourceACLToken_initialCheck(),
+			},
+			{
+				ResourceName:      "nomad_acl_token.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+
+		CheckDestroy: testResourceACLToken_checkDestroy,
+	})
+}
+
+func TestResourceACLToken_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLToken_initialConfig(),
+				Check:  testResourceACLToken_initialCheck(),
+			},
+		},
+
+		CheckDestroy: testResourceACLToken_checkDestroy,
+	})
+}
+
+func TestResourceACLToken_update(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLToken_initialConfig(),
+				Check:  testResourceACLToken_initialCheck(),
+			},
+			{
+				Config: testResourceACLToken_updateConfig(),
+				Check:  testResourceACLToken_updateCheck(),
+			},
+		},
+
+		CheckDestroy: testResourceACLToken_checkDestroy,
+	})
+}
+
+func testResourceACLToken_initialConfig() string {
+	return `
+resource "nomad_acl_token" "test" {
+  name = "Terraform Test Token"
+  type = "client"
+  policies = ["dev", "qa"]
+  global = false
+}
+`
+}
+
+func testResourceACLToken_initialCheck() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		const (
+			name     = "Terraform Test Token"
+			typ      = "client"
+			policies = "2"
+			global   = "false"
+		)
+		resourceState := s.Modules[0].Resources["nomad_acl_token.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		if len(instanceState.ID) < 1 {
+			return fmt.Errorf("expected ID to be set, got %q", instanceState.ID)
+		}
+
+		if len(instanceState.Attributes["secret_id"]) < 1 {
+			return fmt.Errorf("expected secret_id to be set, got %q", instanceState.Attributes["secret_id"])
+		}
+
+		if instanceState.Attributes["name"] != name {
+			return fmt.Errorf("expected name to be %q, is %q in state", name, instanceState.Attributes["name"])
+		}
+
+		if instanceState.Attributes["type"] != typ {
+			return fmt.Errorf("expected type to be %q, is %q in state", typ, instanceState.Attributes["type"])
+		}
+
+		if instanceState.Attributes["global"] != global {
+			return fmt.Errorf("expected global to be %q, is %q in state", global, instanceState.Attributes["global"])
+		}
+		// because policies is a set, it's a pain to try and check the values here
+		if instanceState.Attributes["policies.#"] != policies {
+			return fmt.Errorf("expected policies.# to be %q, is %q in state", policies, instanceState.Attributes["policies.#"])
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		token, _, err := client.ACLTokens().Info(instanceState.ID, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back token %q: %s", instanceState.ID, err)
+		}
+
+		if token.Name != name {
+			return fmt.Errorf("expected name to be %q, is %q in API", name, token.Name)
+		}
+		if token.Type != typ {
+			return fmt.Errorf("expected type to be %q, is %q in API", typ, token.Type)
+		}
+		if token.Global != false {
+			return fmt.Errorf("expected global to be %v, is %v in API", false, token.Global)
+		}
+		if len(token.Policies) != 2 {
+			return fmt.Errorf("expected %d policies, got %v from the API", 2, token.Policies)
+		}
+
+		return nil
+	}
+}
+
+func testResourceACLToken_checkDestroy(s *terraform.State) error {
+	for _, s := range s.Modules[0].Resources {
+		if s.Type != "nomad_acl_token" {
+			continue
+		}
+		if s.Primary == nil {
+			continue
+		}
+		client := testProvider.Meta().(*api.Client)
+		token, _, err := client.ACLTokens().Info(s.Primary.ID, nil)
+		if err != nil && strings.Contains(err.Error(), "404") || token == nil {
+			continue
+		}
+		return fmt.Errorf("Token %q has not been deleted.", token.AccessorID)
+	}
+
+	return nil
+}
+
+func testResourceACLToken_updateConfig() string {
+	return `
+resource "nomad_acl_token" "test" {
+  name = "Updated Terraform Test Token"
+  type = "client"
+  policies = ["dev", "qa", "prod"]
+  global = false
+}
+`
+}
+
+func testResourceACLToken_updateCheck() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		const (
+			name     = "Updated Terraform Test Token"
+			typ      = "client"
+			policies = "3"
+			global   = "false"
+		)
+		resourceState := s.Modules[0].Resources["nomad_acl_token.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		if len(instanceState.ID) < 1 {
+			return fmt.Errorf("expected ID to be set, got %q", instanceState.ID)
+		}
+
+		if len(instanceState.Attributes["secret_id"]) < 1 {
+			return fmt.Errorf("expected secret_id to be set, got %q", instanceState.Attributes["secret_id"])
+		}
+
+		if instanceState.Attributes["name"] != name {
+			return fmt.Errorf("expected name to be %q, is %q in state", name, instanceState.Attributes["name"])
+		}
+
+		if instanceState.Attributes["type"] != typ {
+			return fmt.Errorf("expected type to be %q, is %q in state", typ, instanceState.Attributes["type"])
+		}
+
+		if instanceState.Attributes["global"] != global {
+			return fmt.Errorf("expected global to be %q, is %q in state", global, instanceState.Attributes["global"])
+		}
+		// because policies is a set, it's a pain to try and check the values here
+		if instanceState.Attributes["policies.#"] != policies {
+			return fmt.Errorf("expected policies.# to be %q, is %q in state", policies, instanceState.Attributes["policies.#"])
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		token, _, err := client.ACLTokens().Info(instanceState.ID, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back token %q: %s", instanceState.ID, err)
+		}
+
+		if token.Name != name {
+			return fmt.Errorf("expected name to be %q, is %q in API", name, token.Name)
+		}
+		if token.Type != typ {
+			return fmt.Errorf("expected type to be %q, is %q in API", typ, token.Type)
+		}
+		if token.Global != false {
+			return fmt.Errorf("expected global to be %v, is %v in API", false, token.Global)
+		}
+		if len(token.Policies) != 3 {
+			return fmt.Errorf("expected %d policies, got %v from the API", 3, token.Policies)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_acl_token"
+sidebar_current: "docs-nomad-resource-acl-token"
+description: |-
+  Manages an ACL token in Nomad.
+---
+
+# nomad_acl_token
+
+Manages an ACL token in Nomad.
+
+~> **Warning:** this resource will store any tokens it creates in
+  Terraform's state file. Take care to
+  [protect your state file](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+Creating a token with limited policies:
+
+```hcl
+resource "nomad_acl_token" "ron" {
+  name = "Ron Weasley"
+  type = "client"
+  policies = ["dev", "qa"]
+}
+```
+
+Creating a global token that will be replicated to all regions:
+
+```hcl
+resource "nomad_acl_token" "hermione" {
+  name = "Hermione Granger"
+  type = "client"
+  policies = ["dev", "qa"]
+  global = true
+}
+```
+
+Creating a token with full access to the cluster:
+
+```hcl
+resource "nomad_acl_token" "hagrid" {
+  name = "Rubeus Hagrid"
+  # Hagrid is the keeper of the keys
+  type = "management"
+}
+```
+
+Accessing the token:
+
+```hcl
+resource "nomad_acl_token" "token" {
+  type = "client"
+  policies = ["dev"]
+}
+
+output "nomad_token" {
+  value = "${nomad_acl_token.token.secret_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `type` `(string: <required>)` - The type of token this is. Use `client`
+  for tokens that will have policies associated with them. Use `management`
+  for tokens that can perform any action.
+
+- `name` `(string: "")` - A human-friendly name for this token.
+
+- `policies` `(set: [])` - A set of policy names to associate with this
+  token. Must be set on `client`-type tokens, must not be set on
+  `management`-type tokens. Policies do not need to exist before being
+  used here.
+
+- `global` `(bool: false)` - Whether the token should be replicated to all
+  regions, or if it will only be used in the region it was created in.
+
+In addition to the above arguments, the following attributes are exported and
+can be referenced:
+
+- `accessor_id` `(string)` - A non-sensitive identifier for this token that
+  can be logged and shared safely without granting any access to the cluster.
+
+- `secret_id` `(string)` - The token value itself, which is presented for
+  access to the cluster.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-nomad-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-nomad-resource-acl-token") %>>
+              <a href="/docs/providers/nomad/r/acl_token.html">nomad_acl_token</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-resource-job") %>>
               <a href="/docs/providers/nomad/r/job.html">nomad_job</a>
             </li>


### PR DESCRIPTION
Allow Terraform to declaratively manage Nomad ACL tokens.