### PR TITLE
Increase the test job's cpu.

### DIFF
--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -122,7 +122,7 @@ job "foo" {
             }
 
             resources {
-                cpu = 20
+                cpu = 100
                 memory = 10
             }
 
@@ -153,7 +153,7 @@ job "foo" {
             }
 
             resources {
-                cpu = 20
+                cpu = 100
                 memory = 10
             }
 
@@ -247,7 +247,7 @@ job "bar" {
             }
 
             resources {
-                cpu = 20
+                cpu = 100
                 memory = 10
             }
 
@@ -321,7 +321,7 @@ job "parameterized" {
                 args = ["1"]
             }
             resources {
-                cpu = 20
+                cpu = 100
                 memory = 10
             }
 


### PR DESCRIPTION
Nomad 0.7.1 had an accidental backwards compatibility break and
increased the minimum CPU allocation allowed in the job spec. What was
previously 20 is now 100. This was reported at hashicorp/nomad#3709.

This breaks our tests, which had a CPU allocation of 20. This PR just
increases them to 100, which allows the tests to pass again.

A fix (hashicorp/nomad#3706) has been merged, and will be part of the
next release, but I think it's worthwhile to change our tests and avoid
contributors stumbling into this on their own when running against
0.7.1, even if it'll work again in the next version of Nomad.