### PR TITLE
Add a resource for managing ACL policies.

### DIFF
--- a/nomad/provider.go
+++ b/nomad/provider.go
@@ -53,7 +53,8 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 
 		ResourcesMap: map[string]*schema.Resource{
-			"nomad_job": resourceJob(),
+			"nomad_acl_policy": resourceACLPolicy(),
+			"nomad_job":        resourceJob(),
 		},
 	}
 }

--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -1,0 +1,140 @@
+package nomad
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceACLPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceACLPolicyCreate,
+		Update: resourceACLPolicyUpdate,
+		Delete: resourceACLPolicyDelete,
+		Read:   resourceACLPolicyRead,
+		Exists: resourceACLPolicyExists,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "Unique name for this policy.",
+				Required:    true,
+				Type:        schema.TypeString,
+				ForceNew:    true,
+			},
+
+			"description": {
+				Description: "Description for this policy.",
+				Optional:    true,
+				Type:        schema.TypeString,
+			},
+
+			"rules_hcl": {
+				Description: "HCL or JSON representation of the rules to enforce on this policy. Use file() to specify a file as input.",
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceACLPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	policy := api.ACLPolicy{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Rules:       d.Get("rules_hcl").(string),
+	}
+
+	// upsert our policy
+	log.Printf("[DEBUG] Creating ACL policy %q", policy.Name)
+	_, err := client.ACLPolicies().Upsert(&policy, nil)
+	if err != nil {
+		return fmt.Errorf("error inserting ACLPolicy %q: %s", policy.Name, err.Error())
+	}
+	log.Printf("[DEBUG] Created ACL policy %q", policy.Name)
+	d.SetId(policy.Name)
+
+	return resourceACLPolicyRead(d, meta)
+}
+
+func resourceACLPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	policy := api.ACLPolicy{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Rules:       d.Get("rules_hcl").(string),
+	}
+
+	// upsert our policy
+	log.Printf("[DEBUG] Updating ACL policy %q", policy.Name)
+	_, err := client.ACLPolicies().Upsert(&policy, nil)
+	if err != nil {
+		return fmt.Errorf("error updating ACLPolicy %q: %s", policy.Name, err.Error())
+	}
+	log.Printf("[DEBUG] Updated ACL policy %q", policy.Name)
+
+	return resourceACLPolicyRead(d, meta)
+}
+
+func resourceACLPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	name := d.Id()
+
+	// delete the policy
+	log.Printf("[DEBUG] Deleting ACL policy %q", name)
+	_, err := client.ACLPolicies().Delete(name, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting ACLPolicy %q: %s", name, err.Error())
+	}
+	log.Printf("[DEBUG] Deleted ACL policy %q", name)
+
+	return nil
+}
+
+func resourceACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	name := d.Id()
+
+	// retrie the policy
+	log.Printf("[DEBUG] Reading ACL policy %q", name)
+	policy, _, err := client.ACLPolicies().Info(name, nil)
+	if err != nil {
+		// we have Exists, so no need to handle 404
+		return fmt.Errorf("error reading ACLPolicy %q: %s", name, err.Error())
+	}
+	log.Printf("[DEBUG] Read ACL policy %q", name)
+
+	d.Set("name", policy.Name)
+	d.Set("description", policy.Description)
+	d.Set("rules_hcl", policy.Rules)
+
+	return nil
+}
+
+func resourceACLPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	name := d.Id()
+	log.Printf("[DEBUG] Checking if ACL policy %q exists", name)
+	_, _, err := client.ACLPolicies().Info(name, nil)
+	if err != nil {
+		// As of Nomad 0.4.1, the API client returns an error for 404
+		// rather than a nil result, so we must check this way.
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
+
+		return true, fmt.Errorf("error checking for ACL policy %q: %#v", name, err)
+	}
+
+	return true, nil
+}

--- a/nomad/resource_acl_policy.go
+++ b/nomad/resource_acl_policy.go
@@ -104,7 +104,7 @@ func resourceACLPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	name := d.Id()
 
-	// retrie the policy
+	// retrieve the policy
 	log.Printf("[DEBUG] Reading ACL policy %q", name)
 	policy, _, err := client.ACLPolicies().Info(name, nil)
 	if err != nil {

--- a/nomad/resource_acl_policy_test.go
+++ b/nomad/resource_acl_policy_test.go
@@ -1,0 +1,289 @@
+package nomad
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func TestResourceACLPolicy_import(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLPolicy_initialConfig(name),
+				Check:  testResourceACLPolicy_initialCheck(name),
+			},
+			{
+				ResourceName:      "nomad_acl_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+
+		CheckDestroy: testResourceACLPolicy_checkDestroy(name),
+	})
+}
+
+func TestResourceACLPolicy_basic(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLPolicy_initialConfig(name),
+				Check:  testResourceACLPolicy_initialCheck(name),
+			},
+		},
+
+		CheckDestroy: testResourceACLPolicy_checkDestroy(name),
+	})
+}
+
+func TestResourceACLPolicy_refresh(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLPolicy_initialConfig(name),
+				Check:  testResourceACLPolicy_initialCheck(name),
+			},
+
+			// This should successfully cause the policy to be recreated,
+			// testing the Exists function.
+			{
+				PreConfig: testResourceACLPolicy_delete(t, name),
+				Config:    testResourceACLPolicy_initialConfig(name),
+			},
+		},
+	})
+}
+
+func TestResourceACLPolicy_nameChange(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	newName := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLPolicy_initialConfig(name),
+				Check:  testResourceACLPolicy_initialCheck(name),
+			},
+
+			// Change our name
+			{
+				Config: testResourceACLPolicy_updateConfig(newName),
+				Check:  testResourceACLPolicy_updateCheck(newName),
+			},
+		},
+	})
+}
+
+func TestResourceACLPolicy_update(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-nomad-test")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceACLPolicy_initialConfig(name),
+				Check:  testResourceACLPolicy_initialCheck(name),
+			},
+			{
+				Config: testResourceACLPolicy_updateConfig(name),
+				Check:  testResourceACLPolicy_updateCheck(name),
+			},
+		},
+	})
+}
+
+func testResourceACLPolicy_initialConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nomad_acl_policy" "test" {
+  name = "%s"
+  description = "A Terraform acctest ACL policy"
+  rules_hcl = <<EOT
+namespace "default" {
+  policy = "read"
+  capabilities = ["submit-job"]
+}
+EOT
+}
+`, name)
+}
+
+func testResourceACLPolicy_initialCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		const (
+			description = "A Terraform acctest ACL policy"
+			rules_hcl   = `namespace "default" {
+  policy = "read"
+  capabilities = ["submit-job"]
+}
+`
+		)
+		resourceState := s.Modules[0].Resources["nomad_acl_policy.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		if instanceState.ID != name {
+			return fmt.Errorf("expected ID to be %q, got %q", name, instanceState.ID)
+		}
+
+		if instanceState.Attributes["name"] != name {
+			return fmt.Errorf("expected name to be %q, is %q in state", name, instanceState.Attributes["name"])
+		}
+
+		if instanceState.Attributes["description"] != description {
+			return fmt.Errorf("expected description to be %q, is %q in state", description, instanceState.Attributes["description"])
+		}
+
+		if instanceState.Attributes["rules_hcl"] != rules_hcl {
+			return fmt.Errorf("expected rules_hcl to be %q, is %q in state", rules_hcl, instanceState.Attributes["rules_hcl"])
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		policy, _, err := client.ACLPolicies().Info(name, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back policy %q: %s", name, err)
+		}
+
+		if policy.Name != name {
+			return fmt.Errorf("expected name to be %q, is %q in API", name, policy.Name)
+		}
+		if policy.Description != description {
+			return fmt.Errorf("expected description to be %q, is %q in API", description, policy.Description)
+		}
+		if policy.Rules != rules_hcl {
+			return fmt.Errorf("expected rules_hcl to be %q, is %q in API", rules_hcl, policy.Rules)
+		}
+
+		return nil
+	}
+}
+
+func testResourceACLPolicy_checkExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+		policy, _, err := client.ACLPolicies().Info(name, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back policy: %s", err)
+		}
+		if policy == nil {
+			return fmt.Errorf("no policy returned for %q", name)
+		}
+
+		return nil
+	}
+}
+
+func testResourceACLPolicy_checkDestroy(name string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		client := testProvider.Meta().(*api.Client)
+		policy, _, err := client.ACLPolicies().Info(name, nil)
+		if err != nil && strings.Contains(err.Error(), "404") || policy == nil {
+			return nil
+		}
+		return fmt.Errorf("Policy %q has not been deleted.", name)
+	}
+}
+
+func testResourceACLPolicy_delete(t *testing.T, name string) func() {
+	return func() {
+		client := testProvider.Meta().(*api.Client)
+		_, err := client.ACLPolicies().Delete(name, nil)
+		if err != nil {
+			t.Fatalf("error deleting ACL policy: %s", err)
+		}
+	}
+}
+
+func testResourceACLPolicy_updateConfig(name string) string {
+	return fmt.Sprintf(`
+resource "nomad_acl_policy" "test" {
+  name = "%s"
+  description = "An updated Terraform acctest ACL policy"
+  rules_hcl = <<EOT
+namespace "default" {
+  policy = "read"
+  capabilities = ["submit-job", "read-job"]
+}
+EOT
+}
+`, name)
+}
+
+func testResourceACLPolicy_updateCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		const (
+			description = "An updated Terraform acctest ACL policy"
+			rules_hcl   = `namespace "default" {
+  policy = "read"
+  capabilities = ["submit-job", "read-job"]
+}
+`
+		)
+		resourceState := s.Modules[0].Resources["nomad_acl_policy.test"]
+		if resourceState == nil {
+			return errors.New("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return errors.New("resource has no primary instance")
+		}
+
+		if instanceState.ID != name {
+			return fmt.Errorf("expected ID to be %q, got %q", name, instanceState.ID)
+		}
+
+		if instanceState.Attributes["name"] != name {
+			return fmt.Errorf("expected name to be %q, is %q in state", name, instanceState.Attributes["name"])
+		}
+
+		if instanceState.Attributes["description"] != description {
+			return fmt.Errorf("expected description to be %q, is %q in state", description, instanceState.Attributes["description"])
+		}
+
+		if instanceState.Attributes["rules_hcl"] != rules_hcl {
+			return fmt.Errorf("expected rules_hcl to be %q, is %q in state", rules_hcl, instanceState.Attributes["rules_hcl"])
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		policy, _, err := client.ACLPolicies().Info(name, nil)
+		if err != nil {
+			return fmt.Errorf("error reading back policy %q: %s", name, err)
+		}
+
+		if policy.Name != name {
+			return fmt.Errorf("expected name to be %q, is %q in API", name, policy.Name)
+		}
+		if policy.Description != description {
+			return fmt.Errorf("expected description to be %q, is %q in API", description, policy.Description)
+		}
+		if policy.Rules != rules_hcl {
+			return fmt.Errorf("expected rules_hcl to be %q, is %q in API", rules_hcl, policy.Rules)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "nomad"
+page_title: "Nomad: nomad_acl_policy"
+sidebar_current: "docs-nomad-resource-acl-policy"
+description: |-
+  Manages an ACL policy registered on the Nomad server.
+---
+
+# nomad_acl_policy
+
+Manages an ACL policy registered in Nomad.
+
+## Example Usage
+
+Registering a policy from an HCL file:
+
+```hcl
+resource "nomad_acl_policy" "dev" {
+  name = "dev"
+  description = "Submit jobs to the dev environment."
+  rules_hcl = "${file("${path.module}/dev.hcl")}"
+}
+```
+
+Registering a policy from inline HCL:
+
+```hcl
+resource "nomad_acl_policy" "dev" {
+  name = "dev"
+  description = "Submit jobs to the dev environment."
+  rules_hcl = <<EOT
+namespace "dev" {
+  policy = "write"
+}
+EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` `(string: <required>)` - A unique name for the policy.
+- `rules_hcl` `(string: <required>)` - The contents of the policy to register,
+   as HCL or JSON.
+- `description` `(string: "")` - A description of the policy.

--- a/website/nomad.erb
+++ b/website/nomad.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current("docs-nomad-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-nomad-resource-acl-policy") %>>
+              <a href="/docs/providers/nomad/r/acl_policy.html">nomad_acl_policy</a>
+            </li>
             <li<%= sidebar_current("docs-nomad-resource-job") %>>
               <a href="/docs/providers/nomad/r/job.html">nomad_job</a>
             </li>


### PR DESCRIPTION
Add a new resource that enables the management of ACL policies. It
allows declaratively defining an ACL policy, and Terraform will make
sure it exists in the Nomad cluster.