### PR TITLE
Fix up in-flight errors for 1.2.

### DIFF
--- a/nomad/data_source_regions.go
+++ b/nomad/data_source_regions.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -23,7 +22,7 @@ func dataSourceRegions() *schema.Resource {
 }
 
 func regionsDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	log.Printf("[DEBUG] Reading regions from Nomad")
 	resp, err := client.Regions().List()

--- a/nomad/resource_acl_policy_test.go
+++ b/nomad/resource_acl_policy_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/hashicorp/nomad/api"
 )
 
 func TestResourceACLPolicy_import(t *testing.T) {
@@ -161,7 +159,7 @@ func testResourceACLPolicy_initialCheck(name string) resource.TestCheckFunc {
 			return fmt.Errorf("expected rules_hcl to be %q, is %q in state", rules_hcl, instanceState.Attributes["rules_hcl"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back policy %q: %s", name, err)
@@ -183,7 +181,7 @@ func testResourceACLPolicy_initialCheck(name string) resource.TestCheckFunc {
 
 func testResourceACLPolicy_checkExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back policy: %s", err)
@@ -198,7 +196,7 @@ func testResourceACLPolicy_checkExists(name string) resource.TestCheckFunc {
 
 func testResourceACLPolicy_checkDestroy(name string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil && strings.Contains(err.Error(), "404") || policy == nil {
 			return nil
@@ -209,7 +207,7 @@ func testResourceACLPolicy_checkDestroy(name string) resource.TestCheckFunc {
 
 func testResourceACLPolicy_delete(t *testing.T, name string) func() {
 	return func() {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		_, err := client.ACLPolicies().Delete(name, nil)
 		if err != nil {
 			t.Fatalf("error deleting ACL policy: %s", err)
@@ -268,7 +266,7 @@ func testResourceACLPolicy_updateCheck(name string) resource.TestCheckFunc {
 			return fmt.Errorf("expected rules_hcl to be %q, is %q in state", rules_hcl, instanceState.Attributes["rules_hcl"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back policy %q: %s", name, err)

--- a/nomad/resource_acl_token_test.go
+++ b/nomad/resource_acl_token_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/hashicorp/nomad/api"
 )
 
 func TestResourceACLToken_import(t *testing.T) {
@@ -119,7 +117,7 @@ func testResourceACLToken_initialCheck() resource.TestCheckFunc {
 			return fmt.Errorf("expected policies.# to be %q, is %q in state", policies, instanceState.Attributes["policies.#"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		token, _, err := client.ACLTokens().Info(instanceState.ID, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back token %q: %s", instanceState.ID, err)
@@ -150,7 +148,7 @@ func testResourceACLToken_checkDestroy(s *terraform.State) error {
 		if s.Primary == nil {
 			continue
 		}
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		token, _, err := client.ACLTokens().Info(s.Primary.ID, nil)
 		if err != nil && strings.Contains(err.Error(), "404") || token == nil {
 			continue
@@ -214,7 +212,7 @@ func testResourceACLToken_updateCheck() resource.TestCheckFunc {
 			return fmt.Errorf("expected policies.# to be %q, is %q in state", policies, instanceState.Attributes["policies.#"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		token, _, err := client.ACLTokens().Info(instanceState.ID, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back token %q: %s", instanceState.ID, err)

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -45,7 +45,7 @@ func resourceNamespace() *schema.Resource {
 }
 
 func resourceNamespaceWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	namespace := api.Namespace{
 		Name:        d.Get("name").(string),
@@ -65,7 +65,7 @@ func resourceNamespaceWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting namespace %q", name)
@@ -79,7 +79,7 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	log.Printf("[DEBUG] Reading namespace %q", name)
@@ -98,7 +98,7 @@ func resourceNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNamespaceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	name := d.Id()
 	log.Printf("[DEBUG] Checking if namespace %q exists", name)

--- a/nomad/resource_namespace_test.go
+++ b/nomad/resource_namespace_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/hashicorp/nomad/api"
 )
 
 func TestResourceNamespace_import(t *testing.T) {
@@ -146,7 +144,7 @@ func testResourceNamespace_initialCheck(name string) resource.TestCheckFunc {
 			return fmt.Errorf("expected description to be %q, is %q in state", description, instanceState.Attributes["description"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		namespace, _, err := client.Namespaces().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back namespace %q: %s", name, err)
@@ -165,7 +163,7 @@ func testResourceNamespace_initialCheck(name string) resource.TestCheckFunc {
 
 func testResourceNamespace_checkExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		namespace, _, err := client.Namespaces().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back namespace %q: %s", name, err)
@@ -180,7 +178,7 @@ func testResourceNamespace_checkExists(name string) resource.TestCheckFunc {
 
 func testResourceNamespace_checkDestroy(name string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		namespace, _, err := client.Namespaces().Info(name, nil)
 		if err != nil && strings.Contains(err.Error(), "404") || namespace == nil {
 			return nil
@@ -191,7 +189,7 @@ func testResourceNamespace_checkDestroy(name string) resource.TestCheckFunc {
 
 func testResourceNamespace_delete(t *testing.T, name string) func() {
 	return func() {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		_, err := client.Namespaces().Delete(name, nil)
 		if err != nil {
 			t.Fatalf("error deleting namespace %q: %s", name, err)
@@ -235,7 +233,7 @@ func testResourceNamespace_updateCheck(name string) resource.TestCheckFunc {
 			return fmt.Errorf("expected description to be %q, is %q in state", description, instanceState.Attributes["description"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		namespace, _, err := client.Namespaces().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back namespace %q: %s", name, err)

--- a/nomad/resource_quota_specification.go
+++ b/nomad/resource_quota_specification.go
@@ -80,7 +80,7 @@ func resourceQuotaSpecificationRegionLimits() *schema.Resource {
 }
 
 func resourceQuotaSpecificationWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	spec := api.QuotaSpec{
 		Name:        d.Get("name").(string),
@@ -104,7 +104,7 @@ func resourceQuotaSpecificationWrite(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceQuotaSpecificationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	// delete the quota spec
@@ -119,7 +119,7 @@ func resourceQuotaSpecificationDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceQuotaSpecificationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	// retrieve the policy
@@ -142,7 +142,7 @@ func resourceQuotaSpecificationRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceQuotaSpecificationExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	name := d.Id()
 	log.Printf("[DEBUG] Checking if quota specification %q exists", name)

--- a/nomad/resource_quota_specification_test.go
+++ b/nomad/resource_quota_specification_test.go
@@ -190,7 +190,7 @@ func testResourceQuotaSpecification_initialCheck(name string) resource.TestCheck
 				instanceState.Attributes["limits."+key+".region_limit."+regKey+".cpu"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		spec, _, err := client.Quotas().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back quota specification %q: %s", name, err)
@@ -219,7 +219,7 @@ func testResourceQuotaSpecification_initialCheck(name string) resource.TestCheck
 
 func testResourceQuotaSpecification_checkExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		spec, _, err := client.Quotas().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back quota specification %q: %s", name, err)
@@ -234,7 +234,7 @@ func testResourceQuotaSpecification_checkExists(name string) resource.TestCheckF
 
 func testResourceQuotaSpecification_checkDestroy(name string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		spec, _, err := client.Quotas().Info(name, nil)
 		if err != nil && strings.Contains(err.Error(), "404") || spec == nil {
 			return nil
@@ -247,7 +247,7 @@ func testResourceQuotaSpecification_checkDestroy(name string) resource.TestCheck
 
 func testResourceQuotaSpecification_delete(t *testing.T, name string) func() {
 	return func() {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		_, err := client.Quotas().Delete(name, nil)
 		if err != nil {
 			t.Fatalf("error deleting quota specification %q: %s", name, err)
@@ -344,7 +344,7 @@ func testResourceQuotaSpecification_updateCheck(name string) resource.TestCheckF
 				instanceState.Attributes["limits."+key+".region_limit."+regKey+".memory_mb"])
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		spec, _, err := client.Quotas().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back quota specification %q: %s", name, err)

--- a/nomad/resource_sentinel_policy.go
+++ b/nomad/resource_sentinel_policy.go
@@ -68,7 +68,7 @@ func resourceSentinelPolicy() *schema.Resource {
 }
 
 func resourceSentinelPolicyWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	policy := api.SentinelPolicy{
 		Name:             d.Get("name").(string),
@@ -90,7 +90,7 @@ func resourceSentinelPolicyWrite(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceSentinelPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	log.Printf("[DEBUG] Deleting Sentinel policy %q", name)
@@ -104,7 +104,7 @@ func resourceSentinelPolicyDelete(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceSentinelPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 	name := d.Id()
 
 	log.Printf("[DEBUG] Reading Sentinel policy %q", name)
@@ -125,7 +125,7 @@ func resourceSentinelPolicyRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceSentinelPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client := meta.(ProviderConfig).client
 
 	name := d.Id()
 	log.Printf("[DEBUG] Checking if Sentinel policy %q exists", name)

--- a/nomad/resource_sentinel_policy_test.go
+++ b/nomad/resource_sentinel_policy_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-
-	"github.com/hashicorp/nomad/api"
 )
 
 func TestResourceSentinelPolicy_import(t *testing.T) {
@@ -165,7 +163,7 @@ func testResourceSentinelPolicy_checkAttrs(name, description, sentinelPolicy, sc
 			return fmt.Errorf("expected policy to be %q, is %q in state", sentinelPolicy, strings.TrimSpace(instanceState.Attributes["policy"]))
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.SentinelPolicies().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back policy %q: %s", name, err)
@@ -193,7 +191,7 @@ func testResourceSentinelPolicy_checkAttrs(name, description, sentinelPolicy, sc
 
 func testResourceSentinelPolicy_checkExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil {
 			return fmt.Errorf("error reading back policy: %s", err)
@@ -208,7 +206,7 @@ func testResourceSentinelPolicy_checkExists(name string) resource.TestCheckFunc 
 
 func testResourceSentinelPolicy_checkDestroy(name string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		policy, _, err := client.ACLPolicies().Info(name, nil)
 		if err != nil && strings.Contains(err.Error(), "404") || policy == nil {
 			return nil
@@ -219,7 +217,7 @@ func testResourceSentinelPolicy_checkDestroy(name string) resource.TestCheckFunc
 
 func testResourceSentinelPolicy_delete(t *testing.T, name string) func() {
 	return func() {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(ProviderConfig).client
 		_, err := client.ACLPolicies().Delete(name, nil)
 		if err != nil {
 			t.Fatalf("error deleting ACL policy: %s", err)

--- a/vendor/github.com/hashicorp/nomad/jobspec/parse.go
+++ b/vendor/github.com/hashicorp/nomad/jobspec/parse.go
@@ -51,7 +51,7 @@ func Parse(r io.Reader) (*api.Job, error) {
 	valid := []string{
 		"job",
 	}
-	if err := checkHCLKeys(list, valid); err != nil {
+	if err := helper.CheckHCLKeys(list, valid); err != nil {
 		return nil, err
 	}
 
@@ -136,6 +136,7 @@ func parseJob(result *api.Job, list *ast.ObjectList) error {
 		"id",
 		"meta",
 		"name",
+		"namespace",
 		"periodic",
 		"priority",
 		"region",
@@ -145,7 +146,7 @@ func parseJob(result *api.Job, list *ast.ObjectList) error {
 		"vault",
 		"vault_token",
 	}
-	if err := checkHCLKeys(listVal, valid); err != nil {
+	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "job:")
 	}
 
@@ -275,7 +276,7 @@ func parseGroups(result *api.Job, list *ast.ObjectList) error {
 			"update",
 			"vault",
 		}
-		if err := checkHCLKeys(listVal, valid); err != nil {
+		if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("'%s' ->", n))
 		}
 
@@ -390,7 +391,7 @@ func parseRestartPolicy(final **api.RestartPolicy, list *ast.ObjectList) error {
 		"delay",
 		"mode",
 	}
-	if err := checkHCLKeys(obj.Val, valid); err != nil {
+	if err := helper.CheckHCLKeys(obj.Val, valid); err != nil {
 		return err
 	}
 
@@ -429,7 +430,7 @@ func parseConstraints(result *[]*api.Constraint, list *ast.ObjectList) error {
 			"value",
 			"version",
 		}
-		if err := checkHCLKeys(o.Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 			return err
 		}
 
@@ -512,7 +513,7 @@ func parseEphemeralDisk(result **api.EphemeralDisk, list *ast.ObjectList) error 
 		"size",
 		"migrate",
 	}
-	if err := checkHCLKeys(obj.Val, valid); err != nil {
+	if err := helper.CheckHCLKeys(obj.Val, valid); err != nil {
 		return err
 	}
 
@@ -586,11 +587,13 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			"meta",
 			"resources",
 			"service",
+			"shutdown_delay",
 			"template",
 			"user",
 			"vault",
+			"kill_signal",
 		}
-		if err := checkHCLKeys(listVal, valid); err != nil {
+		if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("'%s' ->", n))
 		}
 
@@ -621,6 +624,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			WeaklyTypedInput: true,
 			Result:           &t,
 		})
+
 		if err != nil {
 			return err
 		}
@@ -706,7 +710,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 				"max_files",
 				"max_file_size",
 			}
-			if err := checkHCLKeys(logsBlock.Val, valid); err != nil {
+			if err := helper.CheckHCLKeys(logsBlock.Val, valid); err != nil {
 				return multierror.Prefix(err, fmt.Sprintf("'%s', logs ->", n))
 			}
 
@@ -762,7 +766,7 @@ func parseTasks(jobName string, taskGroupName string, result *[]*api.Task, list 
 			valid := []string{
 				"file",
 			}
-			if err := checkHCLKeys(dispatchBlock.Val, valid); err != nil {
+			if err := helper.CheckHCLKeys(dispatchBlock.Val, valid); err != nil {
 				return multierror.Prefix(err, fmt.Sprintf("'%s', dispatch_payload ->", n))
 			}
 
@@ -791,7 +795,7 @@ func parseArtifacts(result *[]*api.TaskArtifact, list *ast.ObjectList) error {
 			"mode",
 			"destination",
 		}
-		if err := checkHCLKeys(o.Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 			return err
 		}
 
@@ -863,8 +867,9 @@ func parseTemplates(result *[]*api.Template, list *ast.ObjectList) error {
 			"source",
 			"splay",
 			"env",
+			"vault_grace",
 		}
-		if err := checkHCLKeys(o.Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 			return err
 		}
 
@@ -908,7 +913,7 @@ func parseServices(jobName string, taskGroupName string, task *api.Task, service
 			"check",
 			"address_mode",
 		}
-		if err := checkHCLKeys(o.Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("service (%d) ->", idx))
 		}
 
@@ -919,6 +924,7 @@ func parseServices(jobName string, taskGroupName string, task *api.Task, service
 		}
 
 		delete(m, "check")
+		delete(m, "check_restart")
 
 		if err := mapstructure.WeakDecode(m, &service); err != nil {
 			return err
@@ -935,6 +941,18 @@ func parseServices(jobName string, taskGroupName string, task *api.Task, service
 		if co := checkList.Filter("check"); len(co.Items) > 0 {
 			if err := parseChecks(&service, co); err != nil {
 				return multierror.Prefix(err, fmt.Sprintf("service: '%s',", service.Name))
+			}
+		}
+
+		// Filter check_restart
+		if cro := checkList.Filter("check_restart"); len(cro.Items) > 0 {
+			if len(cro.Items) > 1 {
+				return fmt.Errorf("check_restart '%s': cannot have more than 1 check_restart", service.Name)
+			}
+			if cr, err := parseCheckRestart(cro.Items[0]); err != nil {
+				return multierror.Prefix(err, fmt.Sprintf("service: '%s',", service.Name))
+			} else {
+				service.CheckRestart = cr
 			}
 		}
 
@@ -960,8 +978,12 @@ func parseChecks(service *api.Service, checkObjs *ast.ObjectList) error {
 			"args",
 			"initial_status",
 			"tls_skip_verify",
+			"header",
+			"method",
+			"check_restart",
+			"address_mode",
 		}
-		if err := checkHCLKeys(co.Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(co.Val, valid); err != nil {
 			return multierror.Prefix(err, "check ->")
 		}
 
@@ -970,6 +992,39 @@ func parseChecks(service *api.Service, checkObjs *ast.ObjectList) error {
 		if err := hcl.DecodeObject(&cm, co.Val); err != nil {
 			return err
 		}
+
+		// HCL allows repeating stanzas so merge 'header' into a single
+		// map[string][]string.
+		if headerI, ok := cm["header"]; ok {
+			headerRaw, ok := headerI.([]map[string]interface{})
+			if !ok {
+				return fmt.Errorf("check -> header -> expected a []map[string][]string but found %T", headerI)
+			}
+			m := map[string][]string{}
+			for _, rawm := range headerRaw {
+				for k, vI := range rawm {
+					vs, ok := vI.([]interface{})
+					if !ok {
+						return fmt.Errorf("check -> header -> %q expected a []string but found %T", k, vI)
+					}
+					for _, vI := range vs {
+						v, ok := vI.(string)
+						if !ok {
+							return fmt.Errorf("check -> header -> %q expected a string but found %T", k, vI)
+						}
+						m[k] = append(m[k], v)
+					}
+				}
+			}
+
+			check.Header = m
+
+			// Remove "header" as it has been parsed
+			delete(cm, "header")
+		}
+
+		delete(cm, "check_restart")
+
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 			DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
 			WeaklyTypedInput: true,
@@ -982,10 +1037,61 @@ func parseChecks(service *api.Service, checkObjs *ast.ObjectList) error {
 			return err
 		}
 
+		// Filter check_restart
+		var checkRestartList *ast.ObjectList
+		if ot, ok := co.Val.(*ast.ObjectType); ok {
+			checkRestartList = ot.List
+		} else {
+			return fmt.Errorf("check_restart '%s': should be an object", check.Name)
+		}
+
+		if cro := checkRestartList.Filter("check_restart"); len(cro.Items) > 0 {
+			if len(cro.Items) > 1 {
+				return fmt.Errorf("check_restart '%s': cannot have more than 1 check_restart", check.Name)
+			}
+			if cr, err := parseCheckRestart(cro.Items[0]); err != nil {
+				return multierror.Prefix(err, fmt.Sprintf("check: '%s',", check.Name))
+			} else {
+				check.CheckRestart = cr
+			}
+		}
+
 		service.Checks[idx] = check
 	}
 
 	return nil
+}
+
+func parseCheckRestart(cro *ast.ObjectItem) (*api.CheckRestart, error) {
+	valid := []string{
+		"limit",
+		"grace",
+		"ignore_warnings",
+	}
+
+	if err := helper.CheckHCLKeys(cro.Val, valid); err != nil {
+		return nil, multierror.Prefix(err, "check_restart ->")
+	}
+
+	var checkRestart api.CheckRestart
+	var crm map[string]interface{}
+	if err := hcl.DecodeObject(&crm, cro.Val); err != nil {
+		return nil, err
+	}
+
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		WeaklyTypedInput: true,
+		Result:           &checkRestart,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(crm); err != nil {
+		return nil, err
+	}
+
+	return &checkRestart, nil
 }
 
 func parseResources(result *api.Resources, list *ast.ObjectList) error {
@@ -1016,7 +1122,7 @@ func parseResources(result *api.Resources, list *ast.ObjectList) error {
 		"memory",
 		"network",
 	}
-	if err := checkHCLKeys(listVal, valid); err != nil {
+	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "resources ->")
 	}
 
@@ -1041,7 +1147,7 @@ func parseResources(result *api.Resources, list *ast.ObjectList) error {
 			"mbits",
 			"port",
 		}
-		if err := checkHCLKeys(o.Items[0].Val, valid); err != nil {
+		if err := helper.CheckHCLKeys(o.Items[0].Val, valid); err != nil {
 			return multierror.Prefix(err, "resources, network ->")
 		}
 
@@ -1076,7 +1182,7 @@ func parsePorts(networkObj *ast.ObjectList, nw *api.NetworkResource) error {
 		"mbits",
 		"port",
 	}
-	if err := checkHCLKeys(networkObj, valid); err != nil {
+	if err := helper.CheckHCLKeys(networkObj, valid); err != nil {
 		return err
 	}
 
@@ -1138,7 +1244,7 @@ func parseUpdate(result **api.UpdateStrategy, list *ast.ObjectList) error {
 		"auto_revert",
 		"canary",
 	}
-	if err := checkHCLKeys(o.Val, valid); err != nil {
+	if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 		return err
 	}
 
@@ -1174,7 +1280,7 @@ func parsePeriodic(result **api.PeriodicConfig, list *ast.ObjectList) error {
 		"prohibit_overlap",
 		"time_zone",
 	}
-	if err := checkHCLKeys(o.Val, valid); err != nil {
+	if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 		return err
 	}
 
@@ -1228,7 +1334,7 @@ func parseVault(result *api.Vault, list *ast.ObjectList) error {
 		"change_mode",
 		"change_signal",
 	}
-	if err := checkHCLKeys(listVal, valid); err != nil {
+	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "vault ->")
 	}
 
@@ -1264,7 +1370,7 @@ func parseParameterizedJob(result **api.ParameterizedJobConfig, list *ast.Object
 		"meta_required",
 		"meta_optional",
 	}
-	if err := checkHCLKeys(o.Val, valid); err != nil {
+	if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
 		return err
 	}
 
@@ -1276,32 +1382,4 @@ func parseParameterizedJob(result **api.ParameterizedJobConfig, list *ast.Object
 
 	*result = &d
 	return nil
-}
-
-func checkHCLKeys(node ast.Node, valid []string) error {
-	var list *ast.ObjectList
-	switch n := node.(type) {
-	case *ast.ObjectList:
-		list = n
-	case *ast.ObjectType:
-		list = n.List
-	default:
-		return fmt.Errorf("cannot check HCL keys of type %T", n)
-	}
-
-	validMap := make(map[string]struct{}, len(valid))
-	for _, v := range valid {
-		validMap[v] = struct{}{}
-	}
-
-	var result error
-	for _, item := range list.Items {
-		key := item.Keys[0].Token.Value().(string)
-		if _, ok := validMap[key]; !ok {
-			result = multierror.Append(result, fmt.Errorf(
-				"invalid key: %s", key))
-		}
-	}
-
-	return result
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -488,12 +488,6 @@
 			"revisionTime": "2015-06-09T07:04:31Z"
 		},
 		{
-			"checksumSHA1": "zRx4nYtDhor4fIy+lE2MBkJ6poU=",
-			"path": "github.com/hashicorp/nomad",
-			"revision": "2f245ac7fc9b916eb4af8a62a471dcd0b468a8c8",
-			"revisionTime": "2017-12-20T01:06:39Z"
-		},
-		{
 			"checksumSHA1": "VQKxpGw3rsGOqWTedM/4YVds8PE=",
 			"path": "github.com/hashicorp/nomad/api",
 			"revision": "1292569ac11aacfe8555a6bd94c0faedae2138e7",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -488,6 +488,12 @@
 			"revisionTime": "2015-06-09T07:04:31Z"
 		},
 		{
+			"checksumSHA1": "zRx4nYtDhor4fIy+lE2MBkJ6poU=",
+			"path": "github.com/hashicorp/nomad",
+			"revision": "2f245ac7fc9b916eb4af8a62a471dcd0b468a8c8",
+			"revisionTime": "2017-12-20T01:06:39Z"
+		},
+		{
 			"checksumSHA1": "VQKxpGw3rsGOqWTedM/4YVds8PE=",
 			"path": "github.com/hashicorp/nomad/api",
 			"revision": "1292569ac11aacfe8555a6bd94c0faedae2138e7",
@@ -510,10 +516,10 @@
 			"revisionTime": "2017-06-06T17:46:54Z"
 		},
 		{
-			"checksumSHA1": "PJhcrcP+0rcr5z7KX73Pb+16ydI=",
+			"checksumSHA1": "NsAqYGxyhCKfHIrKd5oFsEzhA7Y=",
 			"path": "github.com/hashicorp/nomad/helper",
-			"revision": "902d759a2ab961c75f784cb34e88416f06a98b59",
-			"revisionTime": "2017-07-26T22:16:21Z",
+			"revision": "2f245ac7fc9b916eb4af8a62a471dcd0b468a8c8",
+			"revisionTime": "2017-12-20T01:06:39Z",
 			"version": "=v0.6.0",
 			"versionExact": "v0.6.0"
 		},
@@ -525,10 +531,10 @@
 			"versionExact": "v0.6.0"
 		},
 		{
-			"checksumSHA1": "HjVXaUUxuWEkZkxZhDzf3gmWTfU=",
+			"checksumSHA1": "EAd9YgDrNaxpu+QeLLT0Y8+kWnc=",
 			"path": "github.com/hashicorp/nomad/jobspec",
-			"revision": "902d759a2ab961c75f784cb34e88416f06a98b59",
-			"revisionTime": "2017-07-26T22:16:21Z",
+			"revision": "2f245ac7fc9b916eb4af8a62a471dcd0b468a8c8",
+			"revisionTime": "2017-12-20T01:06:39Z",
 			"version": "=v0.6.0",
 			"versionExact": "v0.6.0"
 		},


### PR DESCRIPTION
With the push for 1.2, we had a bunch of stuff happening in parallel,
that made some issues when they all landed. Notably, we changed the type
being returned by ProviderConfig, which made every use of meta that
wasn't updated panic. All the uses that were merged at the time were
updated, but the ones in flight when the PR was opened were not, causing
them to panic. This PR fixes that.

The vendor for `jobspec` from Nomad was also updated, as it didn't have
a field for namespace at the time it was vendored, which means that jobs
could not be scheduled in namespaces. Now they can.

All tests now pass:

```
make testacc TEST=./nomad
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./nomad -v  -timeout 120m
=== RUN   TestDataSourceRegions
--- PASS: TestDataSourceRegions (0.17s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestResourceACLPolicy_import
--- PASS: TestResourceACLPolicy_import (0.35s)
=== RUN   TestResourceACLPolicy_basic
--- PASS: TestResourceACLPolicy_basic (0.28s)
=== RUN   TestResourceACLPolicy_refresh
--- PASS: TestResourceACLPolicy_refresh (0.42s)
=== RUN   TestResourceACLPolicy_nameChange
--- PASS: TestResourceACLPolicy_nameChange (0.45s)
=== RUN   TestResourceACLPolicy_update
--- PASS: TestResourceACLPolicy_update (0.44s)
=== RUN   TestResourceACLToken_import
--- PASS: TestResourceACLToken_import (0.32s)
=== RUN   TestResourceACLToken_basic
--- PASS: TestResourceACLToken_basic (0.26s)
=== RUN   TestResourceACLToken_update
--- PASS: TestResourceACLToken_update (0.45s)
=== RUN   TestResourceJob_basic
--- PASS: TestResourceJob_basic (0.20s)
=== RUN   TestResourceJob_refresh
--- PASS: TestResourceJob_refresh (0.27s)
=== RUN   TestResourceJob_disableDestroyDeregister
--- PASS: TestResourceJob_disableDestroyDeregister (0.31s)
=== RUN   TestResourceJob_idChange
--- PASS: TestResourceJob_idChange (0.35s)
=== RUN   TestResourceJob_parameterizedJob
--- PASS: TestResourceJob_parameterizedJob (0.15s)
=== RUN   TestResourceJob_vault
--- PASS: TestResourceJob_vault (0.31s)
=== RUN   TestResourceNamespace_import
--- PASS: TestResourceNamespace_import (0.32s)
=== RUN   TestResourceNamespace_basic
--- PASS: TestResourceNamespace_basic (0.27s)
=== RUN   TestResourceNamespace_refresh
--- PASS: TestResourceNamespace_refresh (0.42s)
=== RUN   TestResourceNamespace_nameChange
--- PASS: TestResourceNamespace_nameChange (0.47s)
=== RUN   TestResourceNamespace_update
--- PASS: TestResourceNamespace_update (0.48s)
=== RUN   TestResourceQuotaSpecification_import
--- PASS: TestResourceQuotaSpecification_import (0.31s)
=== RUN   TestResourceQuotaSpecification_basic
--- PASS: TestResourceQuotaSpecification_basic (0.29s)
=== RUN   TestResourceQuotaSpecification_refresh
--- PASS: TestResourceQuotaSpecification_refresh (0.43s)
=== RUN   TestResourceQuotaSpecification_nameChange
--- PASS: TestResourceQuotaSpecification_nameChange (0.48s)
=== RUN   TestResourceQuotaSpecification_update
--- PASS: TestResourceQuotaSpecification_update (0.45s)
=== RUN   TestResourceSentinelPolicy_import
--- PASS: TestResourceSentinelPolicy_import (0.31s)
=== RUN   TestResourceSentinelPolicy_basic
--- PASS: TestResourceSentinelPolicy_basic (0.28s)
=== RUN   TestResourceSentinelPolicy_nameChange
--- PASS: TestResourceSentinelPolicy_nameChange (0.50s)
=== RUN   TestResourceSentinelPolicy_update
--- PASS: TestResourceSentinelPolicy_update (0.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-nomad/nomad   10.280s
```