### PR TITLE
Enable json jobs as jobpecs

### DIFF
--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -46,6 +46,21 @@ func TestResourceJob_v086(t *testing.T) {
 	})
 }
 
+func TestResourceJob_json(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config: testResourceJob_jsonConfig,
+				Check:  testResourceJob_initialCheck,
+			},
+		},
+
+		CheckDestroy: testResourceJob_checkDestroy("foo-json"),
+	})
+}
+
 func TestResourceJob_refresh(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
@@ -227,6 +242,42 @@ resource "nomad_job" "test" {
 }
 `
 
+var testResourceJob_jsonConfig = `
+resource "nomad_job" "json_test" {
+	json = true
+	jobspec = <<EOT
+{
+  "Datacenters": [ "dc1" ],
+  "ID": "foo-json",
+  "Name": "foo-json",
+  "Type": "service",
+  "TaskGroups": [
+    {
+      "Name": "foo",
+      "Tasks": [{
+        "Config": {
+          "command": "/bin/sleep",
+          "args": [ "1" ]
+        },
+        "Driver": "raw_exec",
+        "Leader": true,
+        "LogConfig": {
+          "MaxFileSizeMB": 10,
+          "MaxFiles": 3
+        },
+        "Name": "foo",
+        "Resources": {
+          "CPU": 100,
+          "MemoryMB": 10
+        }
+      }
+      ]
+    }
+  ]
+}
+	EOT
+}
+`
 var testResourceJob_noDestroy = `
 resource "nomad_job" "test" {
 	deregister_on_destroy = false

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -78,3 +78,6 @@ The following arguments are supported:
 
 - `policy_override` `(bool: false)` - Determines if the job will override any
   soft-mandatory Sentinel policies and register even if they fail.
+
+- `json` `(bool: false)` - Set this to true if your jobspec is stractured with
+  JSON instead of the default HCL.


### PR DESCRIPTION
This will allow using the nomad provider with json built jobspecs.

Example can be found in the tests.