### PR TITLE
Add quota argument to namespace resource

### DIFF
--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -21,6 +21,7 @@ Registering a namespace:
 resource "nomad_namespace" "dev" {
   name = "dev"
   description = "Shared development environment."
+  quota = "dev"
 }
 ```
 
@@ -30,3 +31,4 @@ The following arguments are supported:
 
 - `name` `(string: <required>)` - A unique name for the namespace.
 - `description` `(string: "")` - A description of the namespace.
+- `quota` `(string: "")` - a resource quota to attach to the namespace.


### PR DESCRIPTION
I discovered that one can specify a resource quota when creating a namespace with this resource.  For instance:

```
resource "nomad_quota_specification" "dev" {
  name = "dev"
  description = "dev quota"
  limits {
    region = "global"
    region_limit {
      cpu = 4600
      memory_mb = 4096
    }
  }
}

resource "nomad_namespace" "dev" {
  name = "dev"
  quota = "${nomad_quota_specification.dev.name}"
  description = "Shared development environment."
}
```