### PR TITLE
Monitor job after registration until deployment is complete

### DIFF
--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -3,6 +3,7 @@ package nomad
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
 	"log"
 	"reflect"
 	"strconv"
@@ -56,6 +57,18 @@ func resourceJob() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 				Type:        schema.TypeBool,
+			},
+
+			"deployment_id": {
+				Description: "If detach = false, the ID for the deployment associated with the last job create/update, if one exists.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+
+			"deployment_status": {
+				Description: "If detach = false, the status for the deployment associated with the last job create/update, if one exists.",
+				Computed:    true,
+				Type:        schema.TypeString,
 			},
 
 			"json": {
@@ -151,6 +164,11 @@ func resourceJob() *schema.Resource {
 }
 
 func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
+	timeout := d.Timeout(schema.TimeoutCreate)
+	if !d.IsNewResource() {
+		timeout = d.Timeout(schema.TimeoutUpdate)
+	}
+
 	providerConfig := meta.(ProviderConfig)
 	client := providerConfig.client
 
@@ -177,75 +195,117 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error applying jobspec: %s", err)
 	}
 
+	log.Printf("[DEBUG] job '%s' registered", *job.ID)
 	d.SetId(*job.ID)
 	d.Set("name", job.ID)
 	d.Set("modify_index", strconv.FormatUint(resp.JobModifyIndex, 10))
 
 	evalId := resp.EvalID
 	if !d.Get("detach").(bool) {
-		err, deploymentId := monitorEval(client, evalId)
-		if err != nil {
-			return fmt.Errorf("error returned fetching evaluation while monitoring deployment: %v", err)
+		log.Printf("[DEBUG] will monitor deployment of job '%s'", *job.ID)
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"monitoring_deployment", "monitoring_evaluation"},
+			Target:     []string{"job_scheduled_without_deployment", "deployment_successful"},
+			Refresh:    deploymentStateRefreshFunc(client, evalId),
+			Timeout:    timeout,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
 		}
-		if deploymentId != "" {
-			return monitorDeployment(client, deploymentId)
+
+		state, err := stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"error waiting for job '%s' to deploy successfully: %s",
+				*job.ID, err)
+		}
+
+		deployment := state.(*api.Deployment)
+
+		if deployment != nil {
+			d.Set("deployment_id", deployment.ID)
+			d.Set("deployment_status", deployment.Status)
+		} else {
+			d.Set("deployment_id", "")
+			d.Set("deployment_status", "")
 		}
 	}
 
 	return resourceJobRead(d, meta) // populate other computed attributes
 }
 
-func monitorDeployment(client *api.Client, deploymentId string) error {
-MONITOR:
-	for {
-		deployment, _, err := client.Deployments().Info(deploymentId, nil)
-		if err != nil {
-			return err
-		}
-		switch deployment.Status {
-		case "failed", "successful", "cancelled":
-			break MONITOR
-		default:
-			// don't overwhelm the API server
-			time.Sleep(time.Second)
-			continue
-		}
-	}
-	return nil
+type monitorState struct {
+	// evalId is the evaluation that we are currently monitoring. This will change
+	// along with follow-up evals.
+	evalId string
+
+	// deploymentId is the deployment that we are monitoring. This is captured from the
+	// final evaluation.
+	deploymentId string
 }
 
-func monitorEval(client *api.Client, evalId string) (error, string) {
-	var deploymentId string
-MONITOR:
-	for {
-		eval, _, err := client.Evaluations().Info(evalId, nil)
-		if err != nil {
-			return err, ""
-		}
-
-		fmt.Printf("monitoring eval '%v', status '%v'\n", eval.ID, eval.Status)
-
-		switch eval.Status {
-		case "complete", "failed", "cancelled":
-			deploymentId = eval.DeploymentID
-			break MONITOR
-		default:
-			// don't overwhelm the API server
-			time.Sleep(time.Second)
-			continue
-		}
-
-		// Monitor the next eval in the chain, if present
-		if eval.NextEval != "" {
-			if eval.Wait.Nanoseconds() != 0 {
-				// Skip some unnecessary polling
-				time.Sleep(eval.Wait)
-			}
-			return monitorEval(client, eval.NextEval)
-		}
-		break
+// deploymentStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// the deployment from a job create/update
+func deploymentStateRefreshFunc(client *api.Client, initialEvalId string) resource.StateRefreshFunc {
+	watching := &monitorState{
+		evalId:       initialEvalId,
+		deploymentId: "",
 	}
-	return nil, deploymentId
+	return func() (interface{}, string, error) {
+
+		var deployment *api.Deployment
+		var state string
+		if watching.deploymentId == "" {
+			// monitor the eval
+			log.Printf("[DEBUG] monitoring evaluation '%s'", watching.evalId)
+			eval, _, err := client.Evaluations().Info(watching.evalId, nil)
+			if err != nil {
+				log.Printf("[ERROR] error on Evaluation.Info during deploymentStateRefresh: %s", err)
+				return nil, "", err
+			}
+
+			switch eval.Status {
+			case "complete":
+				// Monitor the next eval in the chain, if present
+				if eval.NextEval != "" {
+					log.Printf("[DEBUG] will monitor follow-up eval '%v'", watching.evalId)
+					watching.evalId = eval.NextEval
+					state = "monitoring_evaluation"
+				} else if eval.DeploymentID != "" {
+					log.Printf("[DEBUG] job has been scheduled, will monitor deployment '%s'", eval.DeploymentID)
+					watching.deploymentId = eval.DeploymentID
+					state = "monitoring_deployment"
+				} else {
+					log.Printf("[WARN] job has been scheduled, but there is no deployment to monitor")
+					state = "job_scheduled_without_deployment"
+				}
+			case "failed", "cancelled":
+				return nil, "", fmt.Errorf("evaluation failed: %v", eval.StatusDescription)
+			default:
+				state = "monitoring_evaluation"
+			}
+		} else {
+			// monitor the deployment
+			deployment, _, err := client.Deployments().Info(watching.deploymentId, nil)
+			if err != nil {
+				log.Printf("[ERROR] error on Deployment.Info during deploymentStateRefresh: %s", err)
+				return nil, "", err
+			}
+			switch deployment.Status {
+			case "successful":
+				log.Printf("[DEBUG] deployment '%s' successful", deployment.ID)
+				state = "deployment_successful"
+			case "failed", "cancelled":
+				log.Printf("[DEBUG] deployment unsuccessful: %s", deployment.StatusDescription)
+				return deployment, "",
+					fmt.Errorf("deployment '%s' terminated with status '%s': '%s'",
+						deployment.ID, deployment.Status, deployment.StatusDescription)
+			default:
+				// don't overwhelm the API server
+				state = "monitoring_deployment"
+			}
+		}
+		return deployment, state, nil
+	}
 }
 
 func resourceJobDeregister(d *schema.ResourceData, meta interface{}) error {
@@ -255,13 +315,13 @@ func resourceJobDeregister(d *schema.ResourceData, meta interface{}) error {
 	// If deregistration is disabled, then do nothing
 	if !d.Get("deregister_on_destroy").(bool) {
 		log.Printf(
-			"[WARN] Job %q will not deregister since 'deregister_on_destroy'"+
+			"[WARN] job %q will not deregister since 'deregister_on_destroy'"+
 				" is false", d.Id())
 		return nil
 	}
 
 	id := d.Id()
-	log.Printf("[DEBUG] Deregistering job: %q", id)
+	log.Printf("[DEBUG] deregistering job: %q", id)
 	_, _, err := client.Jobs().Deregister(id, false, nil)
 	if err != nil {
 		return fmt.Errorf("error deregistering job: %s", err)
@@ -275,23 +335,23 @@ func resourceJobRead(d *schema.ResourceData, meta interface{}) error {
 	client := providerConfig.client
 
 	id := d.Id()
-	log.Printf("[DEBUG] Reading information for job %q", id)
+	log.Printf("[DEBUG] reading information for job %q", id)
 	job, _, err := client.Jobs().Info(id, nil)
 	if err != nil {
 		// As of Nomad 0.4.1, the API client returns an error for 404
 		// rather than a nil result, so we must check this way.
 		if strings.Contains(err.Error(), "404") {
-			log.Printf("[DEBUG] Job %q does not exist, so removing", id)
+			log.Printf("[DEBUG] job %q does not exist, so removing", id)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("error checking for job: %#v", err)
+		return fmt.Errorf("error checking for job: %s", err)
 	}
 
 	allocStubs, _, err := client.Jobs().Allocations(id, false, nil)
 	if err != nil {
-		log.Printf("[WARN] Error listing allocations for Job %q, will return empty list", id)
+		log.Printf("[WARN] error listing allocations for Job %q, will return empty list", id)
 	}
 	allocIds := make([]string, 0, len(allocStubs))
 	for _, a := range allocStubs {

--- a/scripts/stop-nomad.sh
+++ b/scripts/stop-nomad.sh
@@ -4,3 +4,4 @@
 rm -f /tmp/vault-test.pid
 [ -e /tmp/nomad-test.pid ] && echo "Stopping nomad" && kill $(cat /tmp/nomad-test.pid)
 rm -f /tmp/nomad-test.pid
+rm -f /tmp/nomad-test.token

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,13 +100,13 @@ github.com/hashicorp/hcl/json/token
 github.com/hashicorp/hcl2/hcl
 github.com/hashicorp/hcl2/hcl/hclsyntax
 github.com/hashicorp/hcl2/hcldec
-github.com/hashicorp/hcl2/gohcl
+github.com/hashicorp/hcl2/hcled
 github.com/hashicorp/hcl2/hclparse
+github.com/hashicorp/hcl2/gohcl
 github.com/hashicorp/hcl2/ext/typeexpr
 github.com/hashicorp/hcl2/ext/dynblock
-github.com/hashicorp/hcl2/hclwrite
 github.com/hashicorp/hcl2/hcl/json
-github.com/hashicorp/hcl2/hcled
+github.com/hashicorp/hcl2/hclwrite
 # github.com/hashicorp/hil v0.0.0-20190212112733-ab17b08d6590
 github.com/hashicorp/hil
 github.com/hashicorp/hil/ast
@@ -121,6 +121,7 @@ github.com/hashicorp/nomad/api
 github.com/hashicorp/nomad/api/contexts
 # github.com/hashicorp/terraform v0.12.0-rc1
 github.com/hashicorp/terraform/plugin
+github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/helper/schema
 github.com/hashicorp/terraform/helper/validation
 github.com/hashicorp/terraform/terraform
@@ -132,42 +133,41 @@ github.com/hashicorp/terraform/plugin/discovery
 github.com/hashicorp/terraform/providers
 github.com/hashicorp/terraform/provisioners
 github.com/hashicorp/terraform/version
+github.com/hashicorp/terraform/addrs
+github.com/hashicorp/terraform/command/format
 github.com/hashicorp/terraform/config
 github.com/hashicorp/terraform/config/hcl2shim
-github.com/hashicorp/terraform/helper/hashcode
-github.com/hashicorp/terraform/tfdiags
-github.com/hashicorp/terraform/helper/structure
-github.com/hashicorp/terraform/addrs
-github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/configs
+github.com/hashicorp/terraform/configs/configload
+github.com/hashicorp/terraform/helper/config
+github.com/hashicorp/terraform/helper/logging
+github.com/hashicorp/terraform/internal/initwd
+github.com/hashicorp/terraform/plans
+github.com/hashicorp/terraform/states
+github.com/hashicorp/terraform/tfdiags
+github.com/hashicorp/terraform/helper/hashcode
+github.com/hashicorp/terraform/helper/structure
+github.com/hashicorp/terraform/config/module
 github.com/hashicorp/terraform/dag
 github.com/hashicorp/terraform/flatmap
 github.com/hashicorp/terraform/helper/didyoumean
 github.com/hashicorp/terraform/httpclient
 github.com/hashicorp/terraform/lang
 github.com/hashicorp/terraform/moduledeps
-github.com/hashicorp/terraform/plans
 github.com/hashicorp/terraform/plans/objchange
-github.com/hashicorp/terraform/states
 github.com/hashicorp/terraform/states/statefile
 github.com/hashicorp/terraform/helper/acctest
-github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/registry
 github.com/hashicorp/terraform/registry/regsrc
 github.com/hashicorp/terraform/registry/response
 github.com/hashicorp/terraform/svchost/disco
 github.com/hashicorp/terraform/helper/hilmapstructure
-github.com/hashicorp/terraform/lang/blocktoattr
-github.com/hashicorp/terraform/lang/funcs
-github.com/hashicorp/terraform/command/format
-github.com/hashicorp/terraform/configs/configload
-github.com/hashicorp/terraform/helper/config
-github.com/hashicorp/terraform/helper/logging
-github.com/hashicorp/terraform/internal/initwd
-github.com/hashicorp/terraform/svchost
-github.com/hashicorp/terraform/svchost/auth
 github.com/hashicorp/terraform/internal/modsdir
 github.com/hashicorp/terraform/internal/earlyconfig
+github.com/hashicorp/terraform/lang/blocktoattr
+github.com/hashicorp/terraform/lang/funcs
+github.com/hashicorp/terraform/svchost
+github.com/hashicorp/terraform/svchost/auth
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70
 github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/vault v0.10.4
@@ -278,6 +278,7 @@ google.golang.org/appengine/internal/remote_api
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.19.0
 google.golang.org/grpc
+google.golang.org/grpc/test/bufconn
 google.golang.org/grpc/credentials
 google.golang.org/grpc/health
 google.golang.org/grpc/health/grpc_health_v1
@@ -306,7 +307,6 @@ google.golang.org/grpc/resolver/passthrough
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
-google.golang.org/grpc/test/bufconn
 google.golang.org/grpc/credentials/internal
 google.golang.org/grpc/balancer/base
 google.golang.org/grpc/binarylog/grpc_binarylog_v1

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -75,6 +75,9 @@ The following arguments are supported:
 
 - `deregister_on_id_change` `(bool: true)` - Determines if the job will be
   deregistered if the ID of the job in the jobspec changes.
+  
+- `detach` `(bool: true)` - If true, the provider will return immediately
+  after creating or updating, instead of monitoring.  
 
 - `policy_override` `(bool: false)` - Determines if the job will override any
   soft-mandatory Sentinel policies and register even if they fail.


### PR DESCRIPTION
Resolves #56 

This PR adds the option for the Nomad TF provider to monitor the deployment on job create/update, until such time as it completes or fails. This requires that a deployment is created, which requires that the job have an `update` stanza.