### PR TITLE
support namespaces for nomad jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.4.1 (Unreleased)
+
+IMPROVEMENTS:
+* Better support for Nomad namespaces ([#70](https://github.com/terraform-providers/terraform-provider-nomad/issues/70))
+
 ## 1.4.0 (May 20, 2019)
 
 IMPROVEMENTS:

--- a/nomad/data_source_deployments_test.go
+++ b/nomad/data_source_deployments_test.go
@@ -73,7 +73,7 @@ func TestAccDataSourceDeployments(t *testing.T) {
 		},
 
 		// Somewhat-abuse CheckDestroy to actually do our cleanup... :/
-		CheckDestroy: testResourceJob_forceDestroyWithPurge("foo_deploy"),
+		CheckDestroy: testResourceJob_forceDestroyWithPurge("foo_deploy", "default"),
 	})
 }
 

--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -2,51 +2,13 @@ package nomad
 
 import (
 	"fmt"
-	"github.com/hashicorp/nomad/api"
 	"testing"
+
+	"github.com/hashicorp/nomad/api"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
-
-//func cleanupTestJobAndNamespace(jobID, namespace string) resource.TestCheckFunc {
-//	return func(*terraform.State) error {
-//		providerConfig := testProvider.Meta().(ProviderConfig)
-//		client := providerConfig.client
-//		_, _, err := client.Jobs().Deregister(jobID, true, &api.WriteOptions{
-//			Namespace: namespace,
-//		})
-//		if err != nil {
-//			return fmt.Errorf("failed to clean up job %q after test: %s", jobID, err)
-//		}
-//		if namespace != "default" && namespace != "" {
-//			_, err := client.Namespaces().Delete(namespace, nil)
-//			if err != nil {
-//				return fmt.Errorf("failed to clean up namespace %q after test: %s", namespace, err)
-//			}
-//		}
-//		return nil
-//	}
-//}
-//
-//func setupTestJobAndNamespace(job, namespace string) error {
-//	client := testProvider.Meta().(ProviderConfig).client
-//	fmt.Println("setupTestJobAndNamespace")
-//	if namespace != "" && namespace != "default" {
-//		_, err := client.Namespaces().Register(&api.Namespace{
-//			Name: namespace,
-//		}, nil)
-//		if err != nil {
-//			return fmt.Errorf("error creating test namespace: %s", err)
-//		}
-//	}
-//	j, _ := client.Jobs().ParseHCL(testJobHCL(job, namespace), false)
-//	_, _, err := client.Jobs().Register(j, nil)
-//	if err != nil {
-//		return fmt.Errorf("error creating test job: %s", err)
-//	}
-//	return nil
-//}
 
 func TestAccDataSourceNomadJob_Basic(t *testing.T) {
 	job := "testjobds"
@@ -69,11 +31,6 @@ func TestAccDataSourceNomadJob_Basic(t *testing.T) {
 						"data.nomad_job.test-job", "namespace", "default"),
 				),
 			},
-			//{
-			//	Config: testAccCheckDataSourceNomadJobConfigErr,
-			//	Destroy:     false,
-			//	ExpectError: regexp.MustCompile(`.*job not found`),
-			//},
 		},
 	})
 }
@@ -100,10 +57,6 @@ func TestAccDataSourceNomadJob_Namespaced(t *testing.T) {
 						"data.nomad_job.test-job", "namespace", ns),
 				),
 			},
-			//{
-			//	Config:      testAccCheckDataSourceNomadJobWrongNamespace,
-			//	ExpectError: regexp.MustCompile(`.*job not found`),
-			//},
 		},
 	})
 }

--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -2,49 +2,113 @@ package nomad
 
 import (
 	"fmt"
-	"regexp"
+	"github.com/hashicorp/nomad/api"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
+//func cleanupTestJobAndNamespace(jobID, namespace string) resource.TestCheckFunc {
+//	return func(*terraform.State) error {
+//		providerConfig := testProvider.Meta().(ProviderConfig)
+//		client := providerConfig.client
+//		_, _, err := client.Jobs().Deregister(jobID, true, &api.WriteOptions{
+//			Namespace: namespace,
+//		})
+//		if err != nil {
+//			return fmt.Errorf("failed to clean up job %q after test: %s", jobID, err)
+//		}
+//		if namespace != "default" && namespace != "" {
+//			_, err := client.Namespaces().Delete(namespace, nil)
+//			if err != nil {
+//				return fmt.Errorf("failed to clean up namespace %q after test: %s", namespace, err)
+//			}
+//		}
+//		return nil
+//	}
+//}
+//
+//func setupTestJobAndNamespace(job, namespace string) error {
+//	client := testProvider.Meta().(ProviderConfig).client
+//	fmt.Println("setupTestJobAndNamespace")
+//	if namespace != "" && namespace != "default" {
+//		_, err := client.Namespaces().Register(&api.Namespace{
+//			Name: namespace,
+//		}, nil)
+//		if err != nil {
+//			return fmt.Errorf("error creating test namespace: %s", err)
+//		}
+//	}
+//	j, _ := client.Jobs().ParseHCL(testJobHCL(job, namespace), false)
+//	_, _, err := client.Jobs().Register(j, nil)
+//	if err != nil {
+//		return fmt.Errorf("error creating test job: %s", err)
+//	}
+//	return nil
+//}
+
 func TestAccDataSourceNomadJob_Basic(t *testing.T) {
+	job := "testjobds"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testProviders,
-		CheckDestroy: testResourceJob_forceDestroyWithPurge("foo"),
+		CheckDestroy: testResourceJob_forceDestroyWithPurge(job, "default"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceNomadJobConfig,
-			},
-			{
-				Config: testAccCheckDataSourceNomadJobConfigWithJob,
-				Check:  testAccCheckDataSourceNomadJobExists("data.nomad_job.foobaz"),
-			},
-			{
-				Config: testAccCheckDataSourceNomadJobConfigWithJob,
+				Config: testAccJobDataSourceConfig(job),
 				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceNomadJobExists("data.nomad_job.test-job", "default"),
 					resource.TestCheckResourceAttr(
-						"data.nomad_job.foobaz", "name", "foo"),
+						"data.nomad_job.test-job", "name", job),
 					resource.TestCheckResourceAttr(
-						"data.nomad_job.foobaz", "type", "service"),
+						"data.nomad_job.test-job", "type", "batch"),
 					resource.TestCheckResourceAttr(
-						"data.nomad_job.foobaz", "status", "running"),
+						"data.nomad_job.test-job", "priority", "50"),
 					resource.TestCheckResourceAttr(
-						"data.nomad_job.foobaz", "priority", "50"),
+						"data.nomad_job.test-job", "namespace", "default"),
 				),
 			},
-			{
-				Config:      testAccCheckDataSourceNomadJobConfigErr,
-				Destroy:     false,
-				ExpectError: regexp.MustCompile(`.*job not found`),
-			},
+			//{
+			//	Config: testAccCheckDataSourceNomadJobConfigErr,
+			//	Destroy:     false,
+			//	ExpectError: regexp.MustCompile(`.*job not found`),
+			//},
 		},
 	})
 }
 
-func testAccCheckDataSourceNomadJobExists(n string) resource.TestCheckFunc {
+func TestAccDataSourceNomadJob_Namespaced(t *testing.T) {
+	ns := "jobds-test-namespace"
+	job := "testjobds-namespace"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t); testCheckPro(t) },
+		Providers:    testProviders,
+		CheckDestroy: testResourceJob_forceDestroyWithPurge(job, ns),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNSJobDataSourceConfig(job, ns),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceNomadJobExists("data.nomad_job.test-job", ns),
+					resource.TestCheckResourceAttr(
+						"data.nomad_job.test-job", "name", job),
+					resource.TestCheckResourceAttr(
+						"data.nomad_job.test-job", "type", "batch"),
+					resource.TestCheckResourceAttr(
+						"data.nomad_job.test-job", "priority", "50"),
+					resource.TestCheckResourceAttr(
+						"data.nomad_job.test-job", "namespace", ns),
+				),
+			},
+			//{
+			//	Config:      testAccCheckDataSourceNomadJobWrongNamespace,
+			//	ExpectError: regexp.MustCompile(`.*job not found`),
+			//},
+		},
+	})
+}
+
+func testAccDataSourceNomadJobExists(n, namespace string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -61,7 +125,9 @@ func testAccCheckDataSourceNomadJobExists(n string) resource.TestCheckFunc {
 		id := rs.Primary.ID
 
 		// Try to find the job
-		test_job, _, err := client.Jobs().Info(id, nil)
+		test_job, _, err := client.Jobs().Info(id, &api.QueryOptions{
+			Namespace: namespace,
+		})
 
 		if err != nil {
 			return err
@@ -75,40 +141,24 @@ func testAccCheckDataSourceNomadJobExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckNomadJobDestroy(s *terraform.State) error {
-	providerConfig := testProvider.Meta().(ProviderConfig)
-	client := providerConfig.client
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "nomad_job" {
-			continue
-		}
-
-		id := rs.Primary.ID
-
-		_, _, err := client.Jobs().Deregister(id, false, nil)
-		if err != nil {
-			return fmt.Errorf("error deregistering job: %s", err)
-		}
-	}
-
-	return nil
+func testAccNSJobDataSourceConfig(job, ns string) string {
+	return `
+resource "nomad_namespace" "ns-instance" {
+  name = "` + ns + `" 
 }
 
-var testAccCheckDataSourceNomadJobConfig = `
-resource "nomad_job" "foobar" {
+resource "nomad_job" "job-instance" {
 	jobspec = <<EOT
-		job "foo" {
+		job "` + job + `" {
 			datacenters = ["dc1"]
-			type = "service"
+			type = "batch"
+			namespace = "${nomad_namespace.ns-instance.name}"
 			group "foo" {
 				task "foo" {
-					leader = true ## new in Nomad 0.5.6
-
 					driver = "raw_exec"
 					config {
-						command = "/bin/sleep"
-						args = ["1"]
+						command = "/bin/echo"
+						args = ["test"]
 					}
 
 					resources {
@@ -125,16 +175,46 @@ resource "nomad_job" "foobar" {
 		}
 	EOT
 }
-`
 
-var testAccCheckDataSourceNomadJobConfigWithJob = testAccCheckDataSourceNomadJobConfig + `
-data "nomad_job" "foobaz" {
-  job_id               = "foo"
+data "nomad_job" "test-job" {
+  job_id    = "${nomad_job.job-instance.id}"
+  namespace = "${nomad_job.job-instance.namespace}"
 }
 `
+}
 
-var testAccCheckDataSourceNomadJobConfigErr = testAccCheckDataSourceNomadJobConfig + `
-data "nomad_job" "foobar" {
-  job_id               = "foo-missing"
+func testAccJobDataSourceConfig(job string) string {
+	return `
+resource "nomad_job" "job-instance" {
+	jobspec = <<EOT
+		job "` + job + `" {
+			datacenters = ["dc1"]
+			type = "batch"
+			group "foo" {
+				task "foo" {
+					driver = "raw_exec"
+					config {
+						command = "/bin/echo"
+						args = ["test"]
+					}
+
+					resources {
+						cpu = 100
+						memory = 10
+					}
+
+					logs {
+						max_files = 3
+						max_file_size = 10
+					}
+				}
+			}
+		}
+	EOT
+}
+
+data "nomad_job" "test-job" {
+  job_id    = "${nomad_job.job-instance.id}"
 }
 `
+}

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -89,6 +89,12 @@ func resourceJob() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 
+			"namespace": {
+				Description: "The namespace of the job, as dervied from the jobspec.",
+				Computed:    true,
+				Type:        schema.TypeString,
+			},
+
 			"type": {
 				Description: "The type of the job, as derived from the jobspec.",
 				Computed:    true,
@@ -180,6 +186,11 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if job.Namespace == nil || *job.Namespace == "" {
+		defaultNamespace := "default"
+		job.Namespace = &defaultNamespace
+	}
+
 	// Register the job
 	wantModifyIndexStrI, _ := d.GetChange("modify_index")
 	wantModifyIndex, err := strconv.ParseUint(wantModifyIndexStrI.(string), 10, 64)
@@ -195,9 +206,10 @@ func resourceJobRegister(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error applying jobspec: %s", err)
 	}
 
-	log.Printf("[DEBUG] job '%s' registered", *job.ID)
+	log.Printf("[DEBUG] job '%s' registered in namespace '%s'", *job.ID, *job.Namespace)
 	d.SetId(*job.ID)
 	d.Set("name", job.ID)
+	d.Set("namespace", job.Namespace)
 	d.Set("modify_index", strconv.FormatUint(resp.JobModifyIndex, 10))
 
 	evalId := resp.EvalID
@@ -307,16 +319,24 @@ func resourceJobDeregister(d *schema.ResourceData, meta interface{}) error {
 	client := providerConfig.client
 
 	// If deregistration is disabled, then do nothing
-	if !d.Get("deregister_on_destroy").(bool) {
+
+	deregister_on_destroy := d.Get("deregister_on_destroy").(bool)
+	if !deregister_on_destroy {
 		log.Printf(
-			"[WARN] job %q will not deregister since 'deregister_on_destroy'"+
-				" is false", d.Id())
+			"[WARN] job %q will not deregister since "+
+				"'deregister_on_destroy' is %t", d.Id(), deregister_on_destroy)
 		return nil
 	}
 
 	id := d.Id()
 	log.Printf("[DEBUG] deregistering job: %q", id)
-	_, _, err := client.Jobs().Deregister(id, false, nil)
+	opts := &api.WriteOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	_, _, err := client.Jobs().Deregister(id, false, opts)
 	if err != nil {
 		return fmt.Errorf("error deregistering job: %s", err)
 	}
@@ -329,8 +349,14 @@ func resourceJobRead(d *schema.ResourceData, meta interface{}) error {
 	client := providerConfig.client
 
 	id := d.Id()
-	log.Printf("[DEBUG] reading information for job %q", id)
-	job, _, err := client.Jobs().Info(id, nil)
+	opts := &api.QueryOptions{
+		Namespace: d.Get("namespace").(string),
+	}
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	log.Printf("[DEBUG] reading information for job %q in namespace %q", id, opts.Namespace)
+	job, _, err := client.Jobs().Info(id, opts)
 	if err != nil {
 		// As of Nomad 0.4.1, the API client returns an error for 404
 		// rather than a nil result, so we must check this way.
@@ -342,6 +368,7 @@ func resourceJobRead(d *schema.ResourceData, meta interface{}) error {
 
 		return fmt.Errorf("error checking for job: %s", err)
 	}
+	log.Printf("[DEBUG] found job %q in namespace %q", *job.Name, *job.Namespace)
 
 	allocStubs, _, err := client.Jobs().Allocations(id, false, nil)
 	if err != nil {
@@ -358,6 +385,7 @@ func resourceJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("datacenters", job.Datacenters)
 	d.Set("task_groups", jobTaskGroupsRaw(job.TaskGroups))
 	d.Set("allocation_ids", allocIds)
+	d.Set("namespace", job.Namespace)
 	if job.JobModifyIndex != nil {
 		d.Set("modify_index", strconv.FormatUint(*job.JobModifyIndex, 10))
 	} else {
@@ -383,6 +411,11 @@ func resourceJobCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 		return err
 	}
 
+	defaultNamespace := "default"
+	if job.Namespace == nil || *job.Namespace == "" {
+		job.Namespace = &defaultNamespace
+	}
+
 	resp, _, err := client.Jobs().PlanOpts(job, &api.PlanOptions{
 		Diff:           false,
 		PolicyOverride: d.Get("policy_override").(bool),
@@ -397,13 +430,21 @@ func resourceJobCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 	// to the subset of job attributes we include in our schema.
 
 	d.SetNew("name", job.ID)
+	d.SetNew("namespace", job.Namespace)
 	d.SetNew("type", job.Type)
 	d.SetNew("region", job.Region)
 	d.SetNew("datacenters", job.Datacenters)
 
-	// If the id has changed and the config asks us to deregister on id
+	// If the identity has changed and the config asks us to deregister on identity
 	// change then the id field "forces new resource".
-	if d.Id() != *job.ID {
+	if d.Get("namespace") != *job.Namespace {
+		if d.Get("deregister_on_id_change").(bool) {
+			log.Printf("[DEBUG] namespace change forces new resource because deregister_on_id_change is set")
+			d.ForceNew("namespace")
+		} else {
+			log.Printf("[DEBUG] allowing namespace change as update because deregister_on_id_change is not set")
+		}
+	} else if d.Id() != *job.ID {
 		if d.Get("deregister_on_id_change").(bool) {
 			log.Printf("[DEBUG] name change forces new resource because deregister_on_id_change is set")
 			d.ForceNew("id")
@@ -412,7 +453,7 @@ func resourceJobCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 			log.Printf("[DEBUG] allowing name change as update because deregister_on_id_change is not set")
 		}
 	} else {
-		// If the id _isn't_ changing, then we require consistency of the
+		// If the identity (namespace+name) _isn't_ changing, then we require consistency of the
 		// job modify index to ensure that the "old" part of our diff
 		// will show what Nomad currently knows.
 		wantModifyIndexStr := d.Get("modify_index").(string)

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -37,6 +37,21 @@ func TestResourceJob_basic(t *testing.T) {
 	})
 }
 
+func TestResourceJob_namespace(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config: testResourceJob_initialConfigNamespace,
+				Check:  testResourceJob_initialCheckNS(t, "jobresource-test-namespace"),
+			},
+		},
+
+		CheckDestroy: testResourceJob_checkDestroyNS("foo", "jobresource-test-namespace"),
+	})
+}
+
 func TestResourceJob_v086(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
@@ -132,11 +147,33 @@ func TestResourceJob_disableDestroyDeregister(t *testing.T) {
 		},
 
 		// Somewhat-abuse CheckDestroy to clean up
-		CheckDestroy: testResourceJob_forceDestroyWithPurge("foo"),
+		CheckDestroy: testResourceJob_forceDestroyWithPurge("foo", "default"),
 	})
 }
 
 func TestResourceJob_rename(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config: testResourceJob_initialConfig,
+				Check:  testResourceJob_initialCheck(t),
+			},
+			{
+				Config: testResourceJob_renameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testResourceJob_checkDestroy("foo"),
+					testResourceJob_checkExists("bar"),
+				),
+			},
+		},
+
+		CheckDestroy: testResourceJob_checkDestroy("bar"),
+	})
+}
+
+func TestResourceJob_change_namespace(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -256,7 +293,42 @@ resource "nomad_job" "test" {
 					driver = "raw_exec"
 					config {
 						command = "/bin/sleep"
-						args = ["1"]
+						args = ["10"]
+					}
+					
+					resources {
+						cpu = 100
+						memory = 10
+					}
+					
+					logs {
+						max_files = 3
+						max_file_size = 10
+					}
+				}
+			}
+		}
+	EOT
+}
+`
+
+var testResourceJob_initialConfigNamespace = `
+resource "nomad_namespace" "test-namespace" {
+  name = "jobresource-test-namespace" 
+}
+
+resource "nomad_job" "test" {
+	jobspec = <<EOT
+		job "foo" {
+			datacenters = ["dc1"]
+			type = "batch"
+			namespace = "${nomad_namespace.test-namespace.name}"
+			group "foo" {
+				task "foo" {
+					driver = "raw_exec"
+					config {
+						command = "/bin/sleep"
+						args = ["10"]
 					}
 					
 					resources {
@@ -376,6 +448,10 @@ resource "nomad_job" "test" {
 `
 
 func testResourceJob_initialCheck(t *testing.T) r.TestCheckFunc {
+	return testResourceJob_initialCheckNS(t, "default")
+}
+
+func testResourceJob_initialCheckNS(t *testing.T, expectedNamespace string) r.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		resourceState := s.Modules[0].Resources["nomad_job.test"]
@@ -390,15 +466,25 @@ func testResourceJob_initialCheck(t *testing.T) r.TestCheckFunc {
 
 		jobID := instanceState.ID
 
+		if setNamespace, ok := instanceState.Attributes["namespace"]; !ok || setNamespace != expectedNamespace {
+			return errors.New("resource does not have expected namespace")
+		}
+
 		providerConfig := testProvider.Meta().(ProviderConfig)
 		client := providerConfig.client
-		job, _, err := client.Jobs().Info(jobID, nil)
+		job, _, err := client.Jobs().Info(jobID, &api.QueryOptions{
+			Namespace: expectedNamespace,
+		})
 		if err != nil {
 			return fmt.Errorf("error reading back job: %s", err)
 		}
 
 		if got, want := *job.ID, jobID; got != want {
 			return fmt.Errorf("jobID is %q; want %q", got, want)
+		}
+
+		if got, want := *job.Namespace, expectedNamespace; got != want {
+			return fmt.Errorf("job namespace is %q; want %q", got, want)
 		}
 
 		wantAllocs, _, err := client.Jobs().Allocations(jobID, false, nil)
@@ -594,6 +680,10 @@ func testResourceJob_checkExists(jobID string) r.TestCheckFunc {
 }
 
 func testResourceJob_checkDestroy(jobID string) r.TestCheckFunc {
+	return testResourceJob_checkDestroyNS(jobID, "default")
+}
+
+func testResourceJob_checkDestroyNS(jobID, ns string) r.TestCheckFunc {
 	return func(*terraform.State) error {
 		providerConfig := testProvider.Meta().(ProviderConfig)
 		client := providerConfig.client
@@ -601,7 +691,9 @@ func testResourceJob_checkDestroy(jobID string) r.TestCheckFunc {
 		tries := 0
 	TRY:
 		for {
-			job, _, err := client.Jobs().Info(jobID, nil)
+			job, _, err := client.Jobs().Info(jobID, &api.QueryOptions{
+				Namespace: ns,
+			})
 			// This should likely never happen because we aren't purging jobs on delete
 			if err != nil && strings.Contains(err.Error(), "404") || job == nil {
 				return nil
@@ -622,11 +714,13 @@ func testResourceJob_checkDestroy(jobID string) r.TestCheckFunc {
 	}
 }
 
-func testResourceJob_forceDestroyWithPurge(jobID string) r.TestCheckFunc {
+func testResourceJob_forceDestroyWithPurge(jobID, namespace string) r.TestCheckFunc {
 	return func(*terraform.State) error {
 		providerConfig := testProvider.Meta().(ProviderConfig)
 		client := providerConfig.client
-		_, _, err := client.Jobs().Deregister(jobID, true, nil)
+		_, _, err := client.Jobs().Deregister(jobID, true, &api.WriteOptions{
+			Namespace: namespace,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to clean up job %q after test: %s", jobID, err)
 		}

--- a/scripts/start-nomad.sh
+++ b/scripts/start-nomad.sh
@@ -19,7 +19,7 @@ if [ ! -e /tmp/nomad-test.pid ]; then
     sleep 5
 
     http --ignore-stdin POST http://localhost:4646/v1/acl/bootstrap | jq -r '.SecretID' > /tmp/nomad-test.token
-    cat /tmp/nomad-test.token
+    echo export NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
 elif [ -e /tmp/nomad-test.token ]; then 
-  cat /tmp/nomad-test.token
+  echo export NOMAD_TOKEN=$(cat /tmp/nomad-test.token)
 fi


### PR DESCRIPTION
improves the support for Nomad namespaces
* job datasource takes a namespace field
* job datasource and resources have a `namespace` attribute now
* namespace deletion will retry loop to give jobs a chance to be stopped
* more testing
* changing the namespace on a job will result in a new resource being created and the old being deleted

resolves #69 