### PR TITLE
Fix delete default namespace

### DIFF
--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -74,7 +74,7 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 	for {
 		var err error
 		if name == api.DefaultNamespace {
-			log.Printf("[DEBUG] Can't delete namespace %s, clearing attributes instead", api.DefaultNamespace)
+			log.Printf("[DEBUG] Can't delete default namespace, clearing attributes instead")
 			d.Set("description", "Default shared namespace")
 			d.Set("quota", "")
 			err = resourceNamespaceWrite(d, meta)

--- a/nomad/resource_namespace.go
+++ b/nomad/resource_namespace.go
@@ -72,7 +72,16 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting namespace %q", name)
 	retries := 0
 	for {
-		_, err := client.Namespaces().Delete(name, nil)
+		var err error
+		if name == api.DefaultNamespace {
+			log.Printf("[DEBUG] Can't delete namespace %s, clearing attributes instead", api.DefaultNamespace)
+			d.Set("description", "Default shared namespace")
+			d.Set("quota", "")
+			err = resourceNamespaceWrite(d, meta)
+		} else {
+			_, err = client.Namespaces().Delete(name, nil)
+		}
+
 		if err == nil {
 			break
 		} else if retries < 10 {
@@ -87,7 +96,12 @@ func resourceNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("too many failures attempting to delete namespace %q: %s", name, err.Error())
 		}
 	}
-	log.Printf("[DEBUG] Deleted namespace %q", name)
+
+	if name == api.DefaultNamespace {
+		log.Printf("[DEBUG] %s namespace reset", name)
+	} else {
+		log.Printf("[DEBUG] Deleted namespace %q", name)
+	}
 
 	return nil
 }

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -15,7 +15,7 @@ Nomad Enterprise. This is not present in the open source version of Nomad.
 
 Nomad auto-generates a default namespace called `default`. This namespace
 cannot be removed, so destroying a `nomad_namespace` resource where
-`name = "default"` will cause the namespace to be reset to its initial
+`name = "default"` will cause the namespace to be reset to its default
 configuration.
 
 ## Example Usage

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -13,6 +13,11 @@ Provisions a namespace within a Nomad cluster.
 ~> **Enterprise Only!** This API endpoint and functionality only exists in
 Nomad Enterprise. This is not present in the open source version of Nomad.
 
+Nomad auto-generates a default namespace called `default`. This namespace
+cannot be removed, so destroying a `nomad_namespace` resource where
+`name = "default"` will cause the namespace to be reset to its initial
+configuration.
+
 ## Example Usage
 
 Registering a namespace:


### PR DESCRIPTION
Currently if you reference the `default` namespace in your configuration Terraform will fail to destroy it because the API will return a 500 error:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # nomad_namespace.default will be destroyed
  - resource "nomad_namespace" "default" {
      - description = "Default shared namespace" -> null
      - id          = "default" -> null
      - name        = "default" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

nomad_namespace.default: Destroying... [id=default]

Error: error deleting namespace "default": Unexpected response code: 500 (can not delete default namespace)
```

This error can prevent other resources from being destroyed if they depend on this namespace.

This PR prevents this error from happening by not trying to delete the `default` namespace. Instead it resets the `quota` and `description` attributes to their initial values.

Fixes #72 .