### PR TITLE
Prevent error if Nomad server is not available during plan phase

### DIFF
--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -422,7 +422,7 @@ func resourceJobCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 		PolicyOverride: d.Get("policy_override").(bool),
 	}, nil)
 	if err != nil {
-		return fmt.Errorf("error from 'nomad plan': %s", err)
+		log.Printf("[WARN] failed to validate Nomad plan: %s", err)
 	}
 
 	// If we were able to successfully plan then we can safely populate our
@@ -463,7 +463,7 @@ func resourceJobCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 			return fmt.Errorf("invalid modify_index in state: %s", err)
 		}
 
-		if resp.JobModifyIndex != wantModifyIndex {
+		if resp != nil && resp.JobModifyIndex != wantModifyIndex {
 			// Should rarely happen, but might happen if there was a concurrent
 			// other process writing to Nomad since our Read call.
 			return fmt.Errorf("job modify index has changed since last refresh")

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -810,6 +810,20 @@ func TestResourceJob_vault(t *testing.T) {
 	})
 }
 
+func TestResourceJob_serverNotAvailableForPlan(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config:             testResourceJob_invalidNomadServerConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 var testResourceJob_validVaultConfig = `
 provider "nomad" {
 }
@@ -877,6 +891,29 @@ resource "nomad_job" "test" {
 
 					vault {
 						policies = ["default"]
+					}
+				}
+			}
+		}
+	EOT
+}
+`
+
+var testResourceJob_invalidNomadServerConfig = `
+provider "nomad" {
+	address = "http://invalid.example.com"
+}
+
+resource "nomad_job" "test" {
+	jobspec = <<EOT
+		job "test" {
+			datacenters = ["dc1"]
+			type = "batch"
+			group "foo" {
+				task "foo" {
+					driver = "raw_exec"
+					config {
+						command = "/usr/bin/true"
 					}
 				}
 			}


### PR DESCRIPTION
In some workflows the Nomad server may not be available during the planning phase of Terraform (such as when the server is deployed by Terraform as well).

This PR replaces the error with a warning log message so `terraform apply` can start successfully.

Fixes #66.