### PR TITLE
add `auto_promote` key on job tests

### DIFF
--- a/nomad/datasource_nomad_job_test.go
+++ b/nomad/datasource_nomad_job_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceNomadJob_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.nomad_job.test-job", "name", job),
 					resource.TestCheckResourceAttr(
-						"data.nomad_job.test-job", "type", "batch"),
+						"data.nomad_job.test-job", "type", "service"),
 					resource.TestCheckResourceAttr(
 						"data.nomad_job.test-job", "priority", "50"),
 					resource.TestCheckResourceAttr(
@@ -142,7 +142,16 @@ resource "nomad_job" "job-instance" {
 	jobspec = <<EOT
 		job "` + job + `" {
 			datacenters = ["dc1"]
-			type = "batch"
+			type = "service"
+			update {
+			    max_parallel = 2
+				min_healthy_time = "11s"
+				healthy_deadline = "6m"
+				progress_deadline = "11m"
+				auto_revert = true
+				auto_promote = true
+				canary = 1
+			}
 			group "foo" {
 				task "foo" {
 					driver = "raw_exec"

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -1253,6 +1253,7 @@ resource "nomad_job" "test" {
 				healthy_deadline = "6m"
 				progress_deadline = "11m"
 				auto_revert = true
+				auto_promote = true
 				canary = 1
 			}
 

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -622,6 +622,7 @@ func testResourceJob_v086Check(s *terraform.State) error {
       "HealthyDeadline":  360000000000,
       "ProgressDeadline": 720000000000,
       "AutoRevert": true,
+      "AutoPromote": false,
       "Canary": 1
     }`), &expUpdate)
 	if !reflect.DeepEqual(tg.Update, &expUpdate) {
@@ -734,6 +735,11 @@ func testResourceJob_v090Check(s *terraform.State) error {
     ]`), &expSpreads)
 	if !reflect.DeepEqual(job.Spreads, expSpreads) {
 		return fmt.Errorf("job spreads not as expected")
+	}
+
+	// 0.9.2 jobs support auto_promote in the update stanza
+	if exp := job.TaskGroups[0].Update.AutoPromote; exp == nil || *exp != true {
+		return fmt.Errorf("group auto_promote not as expected")
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds explicit tests for `auto_promote` support in the Job resource and data source.

For the data source the job type had to be changed from `batch` to `service` to allow the addition of the `update` stanza.

Closes #68 