### PR TITLE
Support Nomad v0.10.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6
+	github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/hashicorp/vault v0.10.4
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f
-	github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268
+	github.com/hashicorp/nomad/api v0.0.0-20191010200500-0e6af1085602
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/hashicorp/vault v0.10.4
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6 h1:kiTndH1QxgBybn2s/sHk75LDre3hjZ8Ihrb8ycM+9PM=
 github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
+github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268 h1:vqGLw5utD6HsEvEd1vqTZ6nMZHjdc8suiuc5/76GTSo=
+github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4 h1:fTkL0YwjohGyN7AqsDhz6bwcGBpT+xBqi3Qhpw58Juw=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6 h1:kiTndH1QxgB
 github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
 github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268 h1:vqGLw5utD6HsEvEd1vqTZ6nMZHjdc8suiuc5/76GTSo=
 github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
+github.com/hashicorp/nomad/api v0.0.0-20191010200500-0e6af1085602 h1:rpJ6qZg+bTbf29ME0azxxW1zUZKq+Wh8hukVLlH5Bmw=
+github.com/hashicorp/nomad/api v0.0.0-20191010200500-0e6af1085602/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4 h1:fTkL0YwjohGyN7AqsDhz6bwcGBpT+xBqi3Qhpw58Juw=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=

--- a/nomad/core/README.md
+++ b/nomad/core/README.md
@@ -6,7 +6,7 @@ dependencies, but [Nomad](https://github.com/hashicorp/nomad/) is not
 fully migrated yet, so this directory contains dependencies from Nomad that
 are not exposed in the `github.com/hashicorp/nomad/api` module.
 
-Current base version: [82f214630cd6b2f8ef10a562d728062424cd699b](https://github.com/hashicorp/nomad/tree/82f214630cd6b2f8ef10a562d728062424cd699b)
+Current base version: [7b08e19f7268884d46554187b79529b774b29bd5](https://github.com/hashicorp/nomad/tree/7b08e19f7268884d46554187b79529b774b29bd5)
 
 ## Updating Nomad dependency
 

--- a/nomad/core/README.md
+++ b/nomad/core/README.md
@@ -6,7 +6,7 @@ dependencies, but [Nomad](https://github.com/hashicorp/nomad/) is not
 fully migrated yet, so this directory contains dependencies from Nomad that
 are not exposed in the `github.com/hashicorp/nomad/api` module.
 
-Current base version: [7b08e19f7268884d46554187b79529b774b29bd5](https://github.com/hashicorp/nomad/tree/7b08e19f7268884d46554187b79529b774b29bd5)
+Current base version: [0e6af1085602b642f174f5f11ecefe737708c912](https://github.com/hashicorp/nomad/tree/0e6af1085602b642f174f5f11ecefe737708c912)
 
 ## Updating Nomad dependency
 

--- a/nomad/core/jobspec/parse_group.go
+++ b/nomad/core/jobspec/parse_group.go
@@ -293,7 +293,7 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 			"type",
 			"read_only",
 			"hidden",
-			"config",
+			"source",
 		}
 		if err := helper.CheckHCLKeys(item.Val, valid); err != nil {
 			return err
@@ -303,22 +303,6 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 		if err := hcl.DecodeObject(&m, item.Val); err != nil {
 			return err
 		}
-
-		// TODO(dani): this is gross but we don't have ObjectList.Filter here
-		var cfg map[string]interface{}
-		if cfgI, ok := m["config"]; ok {
-			cfgL, ok := cfgI.([]map[string]interface{})
-			if !ok {
-				return fmt.Errorf("Incorrect `config` type, expected map")
-			}
-
-			if len(cfgL) != 1 {
-				return fmt.Errorf("Expected single `config`, found %d", len(cfgL))
-			}
-
-			cfg = cfgL[0]
-		}
-		delete(m, "config")
 
 		var result api.VolumeRequest
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -333,8 +317,6 @@ func parseVolumes(out *map[string]*api.VolumeRequest, list *ast.ObjectList) erro
 		}
 
 		result.Name = n
-		result.Config = cfg
-
 		volumes[n] = &result
 	}
 

--- a/nomad/core/jobspec/parse_service.go
+++ b/nomad/core/jobspec/parse_service.go
@@ -315,6 +315,8 @@ func parseSidecarTask(item *ast.ObjectItem) (*api.SidecarTask, error) {
 
 func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 	valid := []string{
+		"local_service_address",
+		"local_service_port",
 		"upstreams",
 		"config",
 	}

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -195,9 +195,9 @@ func resourceJob() *schema.Resource {
 										Computed: true,
 										Type:     schema.TypeBool,
 									},
-									"config": {
+									"source": {
 										Computed: true,
-										Type:     schema.TypeMap,
+										Type:     schema.TypeString,
 									},
 								},
 							},
@@ -603,7 +603,7 @@ func jobTaskGroupsRaw(tgs []*api.TaskGroup) []interface{} {
 			volumeM["name"] = v.Name
 			volumeM["type"] = v.Type
 			volumeM["read_only"] = v.ReadOnly
-			volumeM["config"] = v.Config
+			volumeM["source"] = v.Source
 
 			volumesI = append(volumesI, volumeM)
 		}

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -789,9 +789,7 @@ func testResourceJob_volumesCheck(s *terraform.State) error {
 			"Name": "data",
 			"Type": "host",
 			"ReadOnly": true,
-			"Config": {
-				"source": "data"
-			}
+			"Source": "data"
 		}
 	}`), &expVolumes)
 	if diff := cmp.Diff(expVolumes, taskGroup.Volumes); diff != "" {
@@ -1346,9 +1344,7 @@ resource "nomad_job" "test" {
 			volume "data" {
 				type = "host"
 				read_only = true
-				config {
-					source = "data"
-				}
+				source = "data"
 			}
 
 			task "foo" {

--- a/vendor/github.com/hashicorp/nomad/api/services.go
+++ b/vendor/github.com/hashicorp/nomad/api/services.go
@@ -165,8 +165,10 @@ type SidecarTask struct {
 
 // ConsulProxy represents a Consul Connect sidecar proxy jobspec stanza.
 type ConsulProxy struct {
-	Upstreams []*ConsulUpstream
-	Config    map[string]interface{}
+	LocalServiceAddress string `mapstructure:"local_service_address"`
+	LocalServicePort    int    `mapstructure:"local_service_port"`
+	Upstreams           []*ConsulUpstream
+	Config              map[string]interface{}
 }
 
 // ConsulUpstream represents a Consul Connect upstream jobspec stanza.

--- a/vendor/github.com/hashicorp/nomad/api/tasks.go
+++ b/vendor/github.com/hashicorp/nomad/api/tasks.go
@@ -366,9 +366,8 @@ func (m *MigrateStrategy) Copy() *MigrateStrategy {
 type VolumeRequest struct {
 	Name     string
 	Type     string
+	Source   string
 	ReadOnly bool `mapstructure:"read_only"`
-
-	Config map[string]interface{}
 }
 
 // VolumeMount represents the relationship between a destination path in a task

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/hashicorp/hcl2/hclwrite
 github.com/hashicorp/hil/ast
 # github.com/hashicorp/logutils v1.0.0
 github.com/hashicorp/logutils
-# github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268
+# github.com/hashicorp/nomad/api v0.0.0-20191010200500-0e6af1085602
 github.com/hashicorp/nomad/api
 github.com/hashicorp/nomad/api/contexts
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,7 +128,7 @@ github.com/hashicorp/hcl2/hclwrite
 github.com/hashicorp/hil/ast
 # github.com/hashicorp/logutils v1.0.0
 github.com/hashicorp/logutils
-# github.com/hashicorp/nomad/api v0.0.0-20190906191921-82f214630cd6
+# github.com/hashicorp/nomad/api v0.0.0-20191007164342-7b08e19f7268
 github.com/hashicorp/nomad/api
 github.com/hashicorp/nomad/api/contexts
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4


### PR DESCRIPTION
Nomad [v0.10.0-rc.1](https://github.com/hashicorp/nomad/releases/tag/v0.10.0-rc1) has been released. 

This PR updates the Nomad API version and other Nomad dependencies to support the new features available in this new version.