### PR TITLE
Update examples

### DIFF
--- a/website/docs/d/job.html.markdown
+++ b/website/docs/d/job.html.markdown
@@ -18,8 +18,8 @@ An error is triggered if zero or more than one result is returned by the query.
 Get the data about a snapshot:
 
 ```hcl
-data "nomad_job" "example1" {
-  job_id = "example_job"
+data "nomad_job" "example" {
+  job_id = "example"
 }
 ```
 

--- a/website/docs/d/regions.html.markdown
+++ b/website/docs/d/regions.html.markdown
@@ -13,27 +13,26 @@ Retrieve a list of regions available in Nomad.
 ## Example Usage
 
 ```hcl
-data "nomad_regions" "regions" {
-}
+data "nomad_regions" "my_regions" {}
 
 data "template_file" "jobs" {
-  count = "${length(data.nomad_regions.regions.regions)}"
+  count    = length(data.nomad_regions.my_regions.regions)
   template = <<EOT
 job "foo" {
   datacenters = ["dc1"]
-  type = "service"
-  region = "$$region"
+  type        = "service"
+  region      = "$${region}"
   # ... rest of your job here
 }
 EOT
-  vars {
-    region = "${data.nomad_regions.regions[count.index]}"
+  vars = {
+    region = data.nomad_regions.my_regions.regions[count.index]
   }
 }
 
 resource "nomad_job" "app" {
-  count = "${length(data.nomad_regions.regions.regions)}"
-  jobspec = "${data.template_file.jobs[count.index].rendered}"
+  count   = length(data.nomad_regions.my_regions.regions)
+  jobspec = data.template_file.jobs[count.index].rendered
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -25,7 +25,7 @@ provider "nomad" {
 
 # Register a job
 resource "nomad_job" "monitoring" {
-  jobspec = "${file("${path.module}/jobspec.hcl")}"
+  jobspec = file("${path.module}/jobspec.hcl")
 }
 ```
 
@@ -70,24 +70,24 @@ to specify multiple providers for multi-region clusters:
 
 ```hcl
 provider "nomad" {
-  address = "http://127.0.0.1:4646"
+  address = "http://nomad.mycompany.com:4646"
   region  = "us"
   alias   = "us"
 }
 
 provider "nomad" {
-  address = "http://127.0.0.1:4646"
+  address = "http://nomad.mycompany.com:4646"
   region  = "eu"
   alias   = "eu"
 }
 
 resource "nomad_job" "nomad_us" {
   provider = nomad.us
-  jobspec  = file("${path.module}/example-us.nomad")
+  jobspec  = file("${path.module}/jobspec-us.nomad")
 }
 
 resource "nomad_job" "nomad_eu" {
   provider = nomad.eu
-  jobspec  = file("${path.module}/example-eu.nomad")
+  jobspec  = file("${path.module}/jobspec-eu.nomad")
 }
 ```

--- a/website/docs/r/acl_policy.html.markdown
+++ b/website/docs/r/acl_policy.html.markdown
@@ -12,23 +12,13 @@ Manages an ACL policy registered in Nomad.
 
 ## Example Usage
 
-Registering a policy from a HCL file with Terraform 0.12 or greater:
+Registering a policy from a HCL file:
 
 ```hcl
 resource "nomad_acl_policy" "dev" {
   name        = "dev"
   description = "Submit jobs to the dev environment."
-  rules_hcl   = file("${path.module}/dev.hcl"
-}
-```
-
-Registering a policy from a HCL file with Terraform 0.11 or prior:
-
-```hcl
-resource "nomad_acl_policy" "dev" {
-  name        = "dev"
-  description = "Submit jobs to the dev environment."
-  rules_hcl   = "${file("${path.module}/dev.hcl")}"
+  rules_hcl   = file("${path.module}/dev.hcl")
 }
 ```
 

--- a/website/docs/r/acl_token.html.markdown
+++ b/website/docs/r/acl_token.html.markdown
@@ -19,8 +19,8 @@ Manages an ACL token in Nomad.
 Creating a token with limited policies:
 
 ```hcl
-resource "nomad_acl_token" "ron" {
-  name     = "Ron Weasley"
+resource "nomad_acl_token" "dakota" {
+  name     = "Dakota"
   type     = "client"
   policies = ["dev", "qa"]
 }
@@ -29,8 +29,8 @@ resource "nomad_acl_token" "ron" {
 Creating a global token that will be replicated to all regions:
 
 ```hcl
-resource "nomad_acl_token" "hermione" {
-  name     = "Hermione Granger"
+resource "nomad_acl_token" "dakota" {
+  name     = "Dakota"
   type     = "client"
   policies = ["dev", "qa"]
   global   = true
@@ -40,10 +40,8 @@ resource "nomad_acl_token" "hermione" {
 Creating a token with full access to the cluster:
 
 ```hcl
-resource "nomad_acl_token" "hagrid" {
-  name = "Rubeus Hagrid"
-
-  # Hagrid is the keeper of the keys
+resource "nomad_acl_token" "iman" {
+  name = "Iman"
   type = "management"
 }
 ```
@@ -57,7 +55,7 @@ resource "nomad_acl_token" "token" {
 }
 
 output "nomad_token" {
-  value = "${nomad_acl_token.token.secret_id}"
+  value = nomad_acl_token.token.secret_id
 }
 ```
 

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -24,7 +24,7 @@ Registering a job from a jobspec file:
 
 ```hcl
 resource "nomad_job" "app" {
-  jobspec = "${file("${path.module}/job.hcl")}"
+  jobspec = file("${path.module}/jobpec.hcl")
 }
 ```
 
@@ -39,22 +39,22 @@ resource "nomad_job" "app" {
   jobspec = <<EOT
 job "foo" {
   datacenters = ["dc1"]
-  type = "service"
+  type        = "service"
   group "foo" {
     task "foo" {
       driver = "raw_exec"
       config {
         command = "/bin/sleep"
-        args = ["1"]
+        args    = ["1"]
       }
 
       resources {
-        cpu = 20
+        cpu    = 20
         memory = 10
       }
 
       logs {
-        max_files = 3
+        max_files     = 3
         max_file_size = 10
       }
     }
@@ -71,7 +71,7 @@ argument `json` to `true`:
 
 ```hcl
 resource "nomad_job" "app" {
-  jobspec = "${file("${path.module}/job.json")}"
+  jobspec = file("${path.module}/jobspec.json")
   json    = true
 }
 ```
@@ -98,9 +98,9 @@ The following arguments are supported:
 
 - `deregister_on_id_change` `(bool: true)` - Determines if the job will be
   deregistered if the ID of the job in the jobspec changes.
-  
+
 - `detach` `(bool: true)` - If true, the provider will return immediately
-  after creating or updating, instead of monitoring.  
+  after creating or updating, instead of monitoring.
 
 - `policy_override` `(bool: false)` - Determines if the job will override any
   soft-mandatory Sentinel policies and register even if they fail.

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -26,14 +26,13 @@ Registering a namespace:
 resource "nomad_namespace" "dev" {
   name        = "dev"
   description = "Shared development environment."
-  quota = "dev"
+  quota       = "dev"
 }
 ```
 
-Registering a namespace with a quota
+Registering a namespace with a quota:
 
 ```hcl
-
 resource "nomad_quota_specification" "web_team" {
   name        = "web-team"
   description = "web team quota"
@@ -49,9 +48,9 @@ resource "nomad_quota_specification" "web_team" {
 }
 
 resource "nomad_namespace" "web" {
-  name = "web"
+  name        = "web"
   description = "Web team production environment."
-  quota = "${nomad_quota_specification.web_team.name}"
+  quota       = nomad_quota_specification.web_team.name
 }
 ```
 


### PR DESCRIPTION
This PR updates the docs to:
* use the Terraform 0.12 syntax
* use consistent names across pages
* format HCL blocks
