### PR TITLE
error in changelog description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.8 (Unreleased)
 ## 1.4.7 (June 12, 2020)
 
-* **Target Nomad 0.11.2**: updated the nomad client to support Nomad API version 0.11.2 ([#113](https://github.com/terraform-providers/terraform-provider-nomad/issues/113))
+* **Target Nomad 0.11.3**: updated the nomad client to support Nomad API version 0.11.3 ([#113](https://github.com/terraform-providers/terraform-provider-nomad/issues/113))
 
 IMPROVEMENTS:
 * resource/nomad_job: allow JSON input to have the same format as produced by the `nomad` CLI ([#111](https://github.com/terraform-providers/terraform-provider-nomad/pull/111))


### PR DESCRIPTION
the changelog entry indicated support for API 0.11.2, but i moved it to 0.11.3 before the release (as suggested by the PR description and verified by the commit SHA in the PR)