### PR TITLE
renamed nomad_job purge_on_delete to purge_on_destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.4.9 (Unreleased)
 
 IMPROVEMENTS: 
-* resource/nomad_job: added `purge_on_delete` option ([#127](https://github.com/terraform-providers/terraform-provider-nomad/issues/127))
+* resource/nomad_job: added `purge_on_destroy` option ([#127](https://github.com/terraform-providers/terraform-provider-nomad/issues/127)][[#130](https://github.com/terraform-providers/terraform-provider-nomad/issues/130))
 * data source/nomad_namespace: added new data source to fetch info a Nomad namespace ([#126](https://github.com/terraform-providers/terraform-provider-nomad/issues/126))
 * data source/nomad_acl_tokens: added new data source to fetch Nomad ACL tokens ([#128](https://github.com/terraform-providers/terraform-provider-nomad/issues/128))
 

--- a/nomad/resource_job.go
+++ b/nomad/resource_job.go
@@ -212,8 +212,8 @@ func resourceJob() *schema.Resource {
 				},
 			},
 
-			"purge_on_delete": {
-				Description: "Whether to purge the job when the resource is deleted.",
+			"purge_on_destroy": {
+				Description: "Whether to purge the job when the resource is destroyed.",
 				Optional:    true,
 				Type:        schema.TypeBool,
 			},
@@ -418,7 +418,7 @@ func resourceJobDeregister(d *schema.ResourceData, meta interface{}) error {
 	if opts.Namespace == "" {
 		opts.Namespace = "default"
 	}
-	purge := d.Get("purge_on_delete").(bool)
+	purge := d.Get("purge_on_destroy").(bool)
 	_, _, err := client.Jobs().Deregister(id, purge, opts)
 	if err != nil {
 		return fmt.Errorf("error deregistering job: %s", err)

--- a/nomad/resource_job_test.go
+++ b/nomad/resource_job_test.go
@@ -401,20 +401,20 @@ func TestResourceJob_parameterizedJob(t *testing.T) {
 	})
 }
 
-func TestResourceJob_purgeOnDelete(t *testing.T) {
+func TestResourceJob_purgeOnDestroy(t *testing.T) {
 	r.Test(t, r.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []r.TestStep{
 			// create the resource
 			{
-				Config: testResourceJob_purgeOnDelete,
+				Config: testResourceJob_purgeOnDestroy,
 				Check:  testResourceJob_initialCheck(t),
 			},
-			// make sure it is purged once deleted
+			// make sure it is purged once deregistered
 			{
 				Destroy: true,
-				Config:  testResourceJob_purgeOnDelete,
+				Config:  testResourceJob_purgeOnDestroy,
 				Check: func(s *terraform.State) error {
 					providerConfig := testProvider.Meta().(ProviderConfig)
 					client := providerConfig.client
@@ -751,9 +751,9 @@ resource "nomad_job" "test" {
 }
 `
 
-var testResourceJob_purgeOnDelete = `
+var testResourceJob_purgeOnDestroy = `
 resource "nomad_job" "test" {
-    purge_on_delete = true
+    purge_on_destroy = true
     jobspec = <<EOT
 		job "foo" {
 			datacenters = ["dc1"]

--- a/website/docs/r/job.html.markdown
+++ b/website/docs/r/job.html.markdown
@@ -96,6 +96,9 @@ The following arguments are supported:
 - `deregister_on_destroy` `(boolean: true)` - Determines if the job will be
   deregistered when this resource is destroyed in Terraform.
 
+- `purge_on_destroy` `(boolean: false)` - Set this to true if you want the job to
+  be purged when the resource is destroyed.
+
 - `deregister_on_id_change` `(boolean: true)` - Determines if the job will be
   deregistered if the ID of the job in the jobspec changes.
 
@@ -107,6 +110,3 @@ The following arguments are supported:
 
 - `json` `(boolean: false)` - Set this to true if your jobspec is structured with
   JSON instead of the default HCL.
-
-- `purge_on_delete` `(boolean: false)` - Set this to true if you want the job to
-  be purged when the resource is deleted.


### PR DESCRIPTION
"delete" does not adhere to either nomad or terraform nomenclature; terraform uses "destroy" for resources, while nomad uses "deregister" for jobs. this is an update to #127 to rename this (which I didn't notice during the PR)

cc: @remilapeyre 