### PR TITLE
refactor travis testing to not eat failed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,17 @@ install:
 - bash scripts/getnomad.sh
 - bash scripts/getvault.sh
 
+
+before_script:
+- bash scripts/start-nomad.sh
+
 script:
 - make vet
-- make localtestacc
+- NOMAD_TOKEN=$(cat /tmp/nomad-test.token) make testacc
 - make website-test
+
+after_scripts:
+- bash scripts/stop-nomad.sh
 
 branches:
   only:

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -17,7 +17,7 @@ func TestDataSourceNamespace(t *testing.T) {
 			{
 				Config: testDataSourceNamespaceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "wrong"),
+					resource.TestCheckResourceAttr(resourceName, "name", "default"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Default shared namespace"),
 					resource.TestCheckResourceAttr(resourceName, "quota", ""),
 				),

--- a/nomad/data_source_namespace_test.go
+++ b/nomad/data_source_namespace_test.go
@@ -17,7 +17,7 @@ func TestDataSourceNamespace(t *testing.T) {
 			{
 				Config: testDataSourceNamespaceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "name", "wrong"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Default shared namespace"),
 					resource.TestCheckResourceAttr(resourceName, "quota", ""),
 				),


### PR DESCRIPTION
modified the travis setup to stop using `make localtestacc`, which was eating any test errors 🤦 

commit 4626dea modifies a test to fail; with the modifications in cd314f7, this fails the build: 
https://travis-ci.org/github/terraform-providers/terraform-provider-nomad/builds/715654929

commit 86f2b24 undoes the failure and passes.